### PR TITLE
Add actions read permission as required by the remote workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,7 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: write


### PR DESCRIPTION
## Summary

This PR adds the actions:read permissions because the remote agentic workflows needs it. Fixes:

<img width="1536" height="139" alt="image" src="https://github.com/user-attachments/assets/70fa59b2-722f-4362-b84c-2313a1e9b1b5" />


