### PR TITLE
Add gh-oblt repository

### DIFF
--- a/active-repositories.json
+++ b/active-repositories.json
@@ -1,5 +1,6 @@
 {
     "repositories": [
+        "elastic/gh-oblt",
         "elastic/oblt-aw",
         "elastic/oblt-cli",
         "elastic/oblt-framework",


### PR DESCRIPTION
## Summary

Add gh-oblt in the list of managed repositories to start using the agentic workflows

Notifies https://github.com/elastic/observability-robots/issues/3614