### PR TITLE
Set Permissions in the right place

### DIFF
--- a/.github/workflows/oblt-aw.yml
+++ b/.github/workflows/oblt-aw.yml
@@ -11,13 +11,14 @@ on:
 
 permissions:
   actions: read
-  contents: write
-  discussions: write
-  issues: write
-  pull-requests: write
 
 jobs:
-  run:
+  run-aw:
+    permissions:
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/oblt-aw-ingress.yml@main # ratchet:exclude
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR sets the job permissions in the right place which is in the job scope. Besides improve the job name.

Notifies https://github.com/elastic/observability-robots/issues/3614