### PR TITLE
Remove duplicated ingress workflow triggers

### DIFF
--- a/.github/workflows/oblt-aw-ingress.yml
+++ b/.github/workflows/oblt-aw-ingress.yml
@@ -1,16 +1,10 @@
 name: Observability Agentic Workflow Ingress
 
 on:
-  schedule:
-    - cron: "0 6 * * *"
   workflow_call:
     secrets:
       COPILOT_GITHUB_TOKEN:
         required: false
-  issues:
-    types: [opened, labeled]
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 permissions:
   actions: read


### PR DESCRIPTION
## Summary
- remove duplicated direct triggers from ingress workflow
- keep  as the only trigger in ingress
- ensure entrypoint workflow remains the single event listener

## Why
The ingress workflow is invoked by , so keeping event triggers in both places can cause duplicate runs.

Notfies https://github.com/elastic/observability-robots/issues/3614