### PR TITLE
enforce no-output rule when no findings in detector and triage workflows

### DIFF
--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
@@ -58,6 +58,9 @@ jobs:
         - **Frequency**: How many times this error has occurred recently
         - **Status**: Whether the workflow run failed or completed with warnings
 
+        **When no findings (No-Op):**
+        When no occurrences of "Resource not accessible by integration" are detected in the last 24 hours, call the `noop` tool with a message explaining the outcome (e.g., "No action needed: no occurrences detected in workflow logs"). Do not create issues for no-op outcomes.
+
         **Issue Creation Requirements:**
         - Issue title MUST start with: `[AI Detector][Resource not accessible by Integration]`
         - Follow the title prefix with a brief description of the scope (e.g., "Detected in 5 workflows across 3 branches")

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -47,6 +47,13 @@ jobs:
         - Label as `oblt-aw/triage/other` if the issue is unrelated to GitHub Actions errors
         - Label as `oblt-aw/triage/needs-info` if there is insufficient information to determine relevance
 
+        **When no action is needed (No-Op):**
+        When your analysis concludes that no triage action is required (e.g., issue is unrelated, insufficient info, duplicate, or out of scope), you MUST call the `noop` tool with a message explaining why. Use the format:
+        ```
+        {"noop": {"message": "No action needed: [brief explanation]"}}
+        ```
+        Do not create issues or post comments for no-op outcomes. The noop primitive provides transparency without creating GitHub artifacts.
+
         **Generate Resolution Plan:**
         When an issue is confirmed to be related to "Resource not accessible by integration" error, append a comprehensive resolution plan to the issue. The plan should analyze the specific error context and provide actionable steps to resolve the permission problem.
 


### PR DESCRIPTION
## Summary

Enforces a strict no-output rule in the `resource-not-accessible-by-integration` agentic workflows so that when no relevant findings are produced, the agent remains completely silent.

## Changes

- `gh-aw-resource-not-accessible-by-integration-detector.yml`: Added **Strict No-Output Rule** as the first instruction — if no occurrences of the target error are found, the agent must not create any issue, post any comment, send any notification, or produce any output.
- `gh-aw-resource-not-accessible-by-integration-triage.yml`: Added the same **Strict No-Output Rule** as the first instruction — if the triaged issue does not match the criteria, the agent must stay silent and produce no output.

## Motivation

Without this guardrail the agent could create noise by posting "nothing found" or "no matches" artifacts, cluttering repositories with zero-value output.
