### PR TITLE
fix(workflows): require agent to apply merge-ready label via add_labels

### DIFF
--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -34,4 +34,8 @@ jobs:
           - Workflows using the dependency are testable in PR context (pull_request or pull_request_target trigger), OR the dependency is dev-only (e.g. pre-commit, linters) with no production impact.
         - Treat "low risk" as sufficient when the above criteria are met. Minor behavioral changes (e.g. ignore-pattern handling, formatting) that do not affect this repo's usage do NOT disqualify the label.
         - Do NOT add `oblt-aw/ai/merge-ready` only when: CVEs/security fixes exist, breaking changes affect this repo, ecosystem checks fail, or workflows are untestable and the dependency has production impact.
+
+        Label application (mandatory):
+        - When ALL criteria for `oblt-aw/ai/merge-ready` are met, you MUST call `add_labels` with that label. Do not only recommend it in the comment; apply it via the add_labels tool.
+        - The comment's "Labels Applied" section must reflect labels you actually applied via add_labels, not merely recommended. If you applied a label, say so; if you did not apply any, say "No labels applied."
     secrets: inherit

--- a/docs/workflows/gh-aw-dependency-review.md
+++ b/docs/workflows/gh-aw-dependency-review.md
@@ -26,6 +26,7 @@ Configured inputs include:
 Labeling semantics (in additional-instructions):
 
 - add `oblt-aw/ai/merge-ready` when: no CVE/GHSA/security fixes, no breaking changes affecting this repo, ecosystem checks pass, and workflows are testable or dependency is dev-only. "Low risk" is sufficient when criteria are met; minor behavioral changes that don't affect repo usage do not disqualify.
+- Label application: when all criteria are met, the agent MUST call `add_labels` with that label (not only recommend in the comment). The comment's "Labels Applied" section must reflect labels actually applied via `add_labels`; if none were applied, it must say "No labels applied."
 
 ## Configuration
 


### PR DESCRIPTION
Related issue: https://github.com/elastic/observability-robots/issues/3730

## Summary
- Add mandatory instructions for the dependency-review agent to call `add_labels` when merge-ready criteria are met (instead of only recommending the label in the comment)
- Require the comment's "Labels Applied" section to reflect labels actually applied via `add_labels`
- Update docs in `docs/workflows/gh-aw-dependency-review.md`

## Validation
- Pre-commit hooks passed (yamllint, ruff, mypy, pre-commit-hooks)
- Workflow YAML is valid

## Risks / Known Gaps
- None; instructions are additive and clarify existing behavior

## Fixes

This tries to fix https://github.com/elastic/oblt-aw/pull/73

```
Labels Applied
No labels applied in this run.

Recommended based on criteria: oblt-aw/ai/merge-ready (low-risk dev tooling update, PR-testable, no security advisories identified).
```

