### PR TITLE
fix(detector): use numeric workflow IDs to avoid 404 in log search API

### DIFF
--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
@@ -19,8 +19,10 @@ jobs:
     steps:
       - id: list
         run: |
+          # Use numeric workflow IDs (not path-derived filenames) to avoid 404 when
+          # the API expects the exact workflow file name (e.g. copilot.yml, not "copilot")
           workflows=$(gh api repos/${{ github.repository }}/actions/workflows \
-            --jq '[.workflows[].path | split("/")[-1]] | tojson')
+            --jq '[.workflows[].id | tostring] | tojson')
           echo "workflows=$workflows" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/workflows/gh-aw-resource-not-accessible-by-integration-detector.md
+++ b/docs/workflows/gh-aw-resource-not-accessible-by-integration-detector.md
@@ -15,7 +15,7 @@ This reusable workflow detects `Resource not accessible by integration` occurren
 
 The workflow uses two jobs:
 
-1. **discover** — Lists all workflow file names via the GitHub API.
+1. **discover** — Lists all workflow numeric IDs via the GitHub API (avoids 404 when the API expects exact workflow file names).
 2. **search** — Matrix job that calls `gh-aw-log-searching-agent` per workflow:
    - `elastic/ai-github-actions/.github/workflows/gh-aw-log-searching-agent.lock.yml@copilot/log-searching-agent-preflight`
 


### PR DESCRIPTION
## Summary

- Use numeric workflow IDs instead of path-derived filenames in the Resource Not Accessible by Integration detector discover job
- Fixes `gh: Not Found (HTTP 404)` when the log-searching-agent calls the GitHub API with workflow_id like `copilot` (missing `.yml` extension)
- The GitHub API accepts both workflow file name and numeric ID; numeric IDs avoid ambiguity

## Validation

- Pre-commit hooks passed (yamllint, check yaml)
- Workflow syntax unchanged; only the discover job jq expression changed

## Risks / Known Gaps

- None; numeric workflow IDs are the recommended API identifier per GitHub docs

Fixes https://github.com/elastic/gh-oblt/actions/runs/23181414399/job/67355070153#step:15:157

Related issue: https://github.com/elastic/observability-robots/issues/3729
