### PR TITLE
fix(workflows): update sync-control-plane-dashboard token policy

### DIFF
--- a/.github/workflows/sync-control-plane-dashboard.yml
+++ b/.github/workflows/sync-control-plane-dashboard.yml
@@ -66,7 +66,7 @@ jobs:
         id: create-token
         uses: elastic/oblt-actions/github/create-token@v1
         with:
-          token-policy: token-policy-63405ab45244
+          token-policy: token-policy-8b60ba56dd3f
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

Updates the token policy used by the sync-control-plane-dashboard workflow when creating ephemeral GitHub tokens for cross-repo dashboard sync.

**Change:** `token-policy-63405ab45244` → `token-policy-8b60ba56dd3f`

## Validation

- Pre-commit hooks passed
- Single-line change in `.github/workflows/sync-control-plane-dashboard.yml`

## Risks / Known Gaps

- None. Token policy rotation for existing workflow.

Related issue: https://github.com/elastic/observability-robots/issues/3732
