### PR TITLE
chore(registry): disable resource-not-accessible-by-integration by default

### DIFF
--- a/workflow-registry.json
+++ b/workflow-registry.json
@@ -33,7 +33,7 @@
       "name": "Resource Not Accessible by Integration",
       "description": "Detects 'Resource not accessible by integration' occurrences in workflow logs, creates triage issues, triages newly opened issues, and executes fixes for issues labeled ready to fix.",
       "maturity": "early-adoption",
-      "default_enabled": true
+      "default_enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Set `default_enabled` to `false` for the `resource-not-accessible-by-integration` entry in `workflow-registry.json`, so new Control Plane Dashboard issues created or updated by the sync script default that workflow to off until a repository checks it.

## Validation

- `python3 -m pytest tests/test_sync_control_plane_dashboard.py -q` — 15 passed

## Risks / Known gaps

- Repositories that already have a dashboard issue are unchanged until the next sync merges new workflow lines; existing checkbox state is preserved.
- When no dashboard issue exists, client behavior is unchanged (ingress still enables all workflows when `enabled_workflows` is empty).

Related issue: https://github.com/elastic/observability-robots/issues/3729
