### PR TITLE
fix(workflows): align issue triage and duplicate detector with dashboard gating

### DIFF
--- a/.github/workflows/oblt-aw-ingress.yml
+++ b/.github/workflows/oblt-aw-ingress.yml
@@ -72,23 +72,23 @@ jobs:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 
   duplicate-issue-detector:
-    needs: normalize-enabled-workflows
+    needs: dashboard-enabled-workflows
     if: >-
       (
         (github.event_name == 'issues' && github.event.action == 'opened') ||
         github.event_name == 'workflow_dispatch'
       ) &&
-      (inputs.enabled_workflows == '' || contains(fromJSON(needs.normalize-enabled-workflows.outputs.ENABLED_WORKFLOWS_JSON), 'duplicate-issue-detector'))
+      (needs['dashboard-enabled-workflows'].outputs['effective-raw'] == '' || contains(fromJSON(needs['dashboard-enabled-workflows'].outputs['enabled-workflows']), 'duplicate-issue-detector'))
     uses: ./.github/workflows/gh-aw-duplicate-issue-detector.yml
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 
   issue-triage:
-    needs: normalize-enabled-workflows
+    needs: dashboard-enabled-workflows
     if: >-
       github.event_name == 'issues' &&
       github.event.action == 'opened' &&
-      (inputs.enabled_workflows == '' || contains(fromJSON(needs.normalize-enabled-workflows.outputs.ENABLED_WORKFLOWS_JSON), 'issue-triage'))
+      (needs['dashboard-enabled-workflows'].outputs['effective-raw'] == '' || contains(fromJSON(needs['dashboard-enabled-workflows'].outputs['enabled-workflows']), 'issue-triage'))
     uses: ./.github/workflows/gh-aw-issue-triage.yml
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Updated `duplicate-issue-detector` and `issue-triage` jobs in `oblt-aw-ingress.yml` to depend on `dashboard-enabled-workflows` and gate with `effective-raw` and `enabled-workflows` from `get-enabled-workflows.yml`, matching the rest of the ingress.
- Removed stale references to the non-existent `normalize-enabled-workflows` job and `ENABLED_WORKFLOWS_JSON` output.

## Validation
- Pre-commit hooks (yamllint, workflow lint) passed on commit.
- Ingress conditions align with other routed jobs (empty `effective-raw` when no dashboard enables all workflows; otherwise checkbox gating).

## Risks / Known Gaps
- None identified; behavior matches documented dashboard gating for other agentic workflows.

Related issue: https://github.com/elastic/observability-robots/issues/3863
