### PR TITLE
chore(workflows): drop target-repositories from res-not-accessible triage/fixer

### DIFF
--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
@@ -1,12 +1,6 @@
 name: Resource not accessible by Integration Issue Fixer
 on:
   workflow_call:
-    inputs:
-      target-repositories:
-        description: JSON array with allowed repositories. [] allows all repositories.
-        required: false
-        type: string
-        default: "[]"
 
 permissions:
   actions: read
@@ -19,11 +13,7 @@ jobs:
   run:
     if: >-
       github.event.label.name == 'oblt-aw/ai/fix-ready' &&
-      contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration') &&
-      (
-        fromJSON(inputs.target-repositories)[0] == null ||
-        contains(fromJSON(inputs.target-repositories), github.repository)
-      )
+      contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
       additional-instructions: |

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -1,12 +1,6 @@
 name: Resource not accessible by Integration Issue Triage
 on:
   workflow_call:
-    inputs:
-      target-repositories:
-        description: JSON array with allowed repositories. [] allows all repositories.
-        required: false
-        type: string
-        default: "[]"
     secrets:
       COPILOT_GITHUB_TOKEN:
         required: true
@@ -20,9 +14,6 @@ permissions:
 
 jobs:
   run:
-    if: >-
-      fromJSON(inputs.target-repositories)[0] == null ||
-      contains(fromJSON(inputs.target-repositories), github.repository)
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
       additional-instructions: |

--- a/docs/architecture/security-agent-architecture.md
+++ b/docs/architecture/security-agent-architecture.md
@@ -68,10 +68,6 @@ The detector implements the full ruleset in `docs/workflows/security-scanning-ru
 
 - `COPILOT_GITHUB_TOKEN` — Required for detector, triage, and fixer (issue/PR creation and updates, API access).
 
-### Inputs
-
-- `target-repositories` — JSON array; default `[]` allows all; non-empty restricts triage/fixer to listed repositories.
-
 ## Deliverables
 
 1. **Detector** — Workflow that checks out the caller repository and runs the checks defined in the ruleset for all applicable SEC-* rules (shellcheck, pattern scanners, optional ecosystem audits).

--- a/docs/routing/resource-not-accessible-by-integration-routing.md
+++ b/docs/routing/resource-not-accessible-by-integration-routing.md
@@ -24,10 +24,7 @@ Routing rules from ingress:
   - issue contains label `oblt-aw/triage/res-not-accessible-by-integration`
   -> fixer
 
-Repository filter behavior when called directly:
-
-- **Detector**: Runs in each repository that invokes it (no filter).
-- **Triage/Fixer**: input `target-repositories` exists; default `[]` allows all; non-empty array restricts to listed repositories.
+When called directly, **detector**, **triage**, and **fixer** all run in the repository that invokes the reusable workflow (no extra repository allowlist).
 
 ## References
 

--- a/docs/workflows/gh-aw-resource-not-accessible-by-integration-fixer.md
+++ b/docs/workflows/gh-aw-resource-not-accessible-by-integration-fixer.md
@@ -27,8 +27,6 @@ Configured instructions require:
 - reviewer request to `elastic/observablt-ci`
 - no auto-merge
 
-Repository filter behavior uses `target-repositories` with default `[]` as allow-all.
-
 ## Configuration
 
 Permissions:
@@ -43,7 +41,7 @@ Permissions:
 
 `workflow_call` contract:
 
-- Input: `target-repositories` (string JSON array, default `[]`)
+- No inputs.
 
 ## References
 

--- a/docs/workflows/gh-aw-resource-not-accessible-by-integration-triage.md
+++ b/docs/workflows/gh-aw-resource-not-accessible-by-integration-triage.md
@@ -24,8 +24,6 @@ Configured instructions define:
 - when to set `oblt-aw/ai/fix-ready`
 - required resolution plan structure
 
-Repository filter behavior uses `target-repositories` with the same semantics as detector/fixer.
-
 ## Configuration
 
 Permissions:
@@ -40,7 +38,6 @@ Permissions:
 
 `workflow_call` contract:
 
-- Input: `target-repositories` (string JSON array, default `[]`)
 - Secret: `COPILOT_GITHUB_TOKEN` (`required: true`)
 
 ## References


### PR DESCRIPTION
## Summary

Remove the unused `target-repositories` `workflow_call` input from the Resource Not Accessible by Integration triage and fixer workflows, and drop the job-level allowlist conditions that only repeated the default “allow all” behavior. Ingress did not pass this input.

## Validation

- Pre-commit hooks ran on commit: YAML check and workflow lint passed.

## Risks

- Any external caller that passed `target-repositories` must stop passing it (contract change).

Related issue: https://github.com/elastic/observability-robots/issues/3729
