### PR TITLE
fix(workflows): use __original_require__ for tsx in gh-aw-automerge

### DIFF
--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -53,9 +53,11 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const path = require('node:path');
+            const nodeRequire = __original_require__;
             const root = path.join(process.env.GITHUB_WORKSPACE, '_oblt-aw');
-            require(require.resolve('tsx/cjs/api', { paths: [root] })).register();
-            const { run } = require(path.join(root, 'scripts/findAutomergeCandidates.ts'));
+            const tsxApi = nodeRequire.resolve('tsx/cjs/api', { paths: [root] });
+            nodeRequire(tsxApi).register();
+            const { run } = nodeRequire(path.join(root, 'scripts/findAutomergeCandidates.ts'));
             const { prNumbers } = await run({
               github,
               context,
@@ -116,8 +118,10 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const path = require('node:path');
+            const nodeRequire = __original_require__;
             const root = path.join(process.env.GITHUB_WORKSPACE, '_oblt-aw');
-            require(require.resolve('tsx/cjs/api', { paths: [root] })).register();
-            const { run } = require(path.join(root, 'scripts/enableAutomergeForApprovedPrs.ts'));
+            const tsxApi = nodeRequire.resolve('tsx/cjs/api', { paths: [root] });
+            nodeRequire(tsxApi).register();
+            const { run } = nodeRequire(path.join(root, 'scripts/enableAutomergeForApprovedPrs.ts'));
             const prNumbers = JSON.parse(process.env.PR_NUMBERS_JSON || '[]');
             await run({ github, context, core, prNumbers });


### PR DESCRIPTION
## Summary

Fixes the `discover` job in the reusable **Automerge** workflow when using `actions/github-script@v8`. The action wraps `require` and resolves npm packages from `process.cwd()` only, so `require.resolve('tsx/cjs/api', { paths: [_oblt-aw] })` did not load `tsx` from the checked-out `elastic/oblt-aw` tree, which produced `MODULE_NOT_FOUND` on consumer workflows (for example `elastic/gh-oblt`).

## Changes

- Use `__original_require__` (documented escape hatch in github-script) to resolve and load `tsx` and the TypeScript entrypoints under `_oblt-aw`.

## Validation

- Repository pre-commit hooks passed on commit (YAML and workflow lint).

Related issue: n/a (observed via failing discover step / `tsx/cjs/api` resolution in consumer CI).
