### PR TITLE
fix(workflows): pin gh-aw Copilot model to gpt-4.1 for AWF

### DIFF
--- a/.github/workflows/gh-aw-agent-suggestions.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.yml
@@ -15,8 +15,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       title-prefix: "[oblt-aw][agent-suggestions]"
       additional-instructions: |
         Additional requirements for this repository:

--- a/.github/workflows/gh-aw-agent-suggestions.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.yml
@@ -15,6 +15,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       title-prefix: "[oblt-aw][agent-suggestions]"
       additional-instructions: |
         Additional requirements for this repository:

--- a/.github/workflows/gh-aw-autodoc.yml
+++ b/.github/workflows/gh-aw-autodoc.yml
@@ -17,6 +17,8 @@ jobs:
   audit:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       lookback-window: 1 day ago
       title-prefix: "[oblt-aw][autodoc]"
       additional-instructions: |
@@ -44,6 +46,8 @@ jobs:
     if: needs.audit.outputs.created_issue_number != ''
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       target-issue-number: ${{ needs.audit.outputs.created_issue_number }}
       draft-prs: true
       additional-instructions: |

--- a/.github/workflows/gh-aw-autodoc.yml
+++ b/.github/workflows/gh-aw-autodoc.yml
@@ -17,8 +17,8 @@ jobs:
   audit:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       lookback-window: 1 day ago
       title-prefix: "[oblt-aw][autodoc]"
       additional-instructions: |
@@ -46,8 +46,8 @@ jobs:
     if: needs.audit.outputs.created_issue_number != ''
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       target-issue-number: ${{ needs.audit.outputs.created_issue_number }}
       draft-prs: true
       additional-instructions: |

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -62,6 +62,8 @@ jobs:
     if: needs.verify.outputs.proceed == 'true'
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Target pull request number: ${{ github.event.pull_request.number }}.
       prompt: |

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -62,8 +62,8 @@ jobs:
     if: needs.verify.outputs.proceed == 'true'
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Target pull request number: ${{ github.event.pull_request.number }}.
       prompt: |

--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -15,8 +15,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       allowed-bot-users: "dependabot[bot],renovate[bot],Dependabot,Renovate,elastic-vault-github-plugin-prod[bot]"
       classification-labels: "oblt-aw/ai/merge-ready"
       additional-instructions: |

--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -15,6 +15,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       allowed-bot-users: "dependabot[bot],renovate[bot],Dependabot,Renovate,elastic-vault-github-plugin-prod[bot]"
       classification-labels: "oblt-aw/ai/merge-ready"
       additional-instructions: |

--- a/.github/workflows/gh-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/gh-aw-duplicate-issue-detector.yml
@@ -15,5 +15,8 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@main
+    with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/gh-aw-duplicate-issue-detector.yml
@@ -16,7 +16,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-issue-triage.yml
+++ b/.github/workflows/gh-aw-issue-triage.yml
@@ -17,7 +17,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-issue-triage.yml
+++ b/.github/workflows/gh-aw-issue-triage.yml
@@ -16,5 +16,8 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
+    with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-mention-in-issue.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-mention-in-issue.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.yml
@@ -18,5 +18,8 @@ jobs:
       issues: write
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@main
+    with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
@@ -35,6 +35,8 @@ jobs:
         workflow: ${{ fromJSON(needs.discover.outputs.workflows) }}
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-log-searching-agent.lock.yml@copilot/log-searching-agent-preflight
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       workflow: ${{ matrix.workflow }}
       search-terms: "Resource not accessible by integration"
       days: 1

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
@@ -35,8 +35,8 @@ jobs:
         workflow: ${{ fromJSON(needs.discover.outputs.workflows) }}
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-log-searching-agent.lock.yml@copilot/log-searching-agent-preflight
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       workflow: ${{ matrix.workflow }}
       search-terms: "Resource not accessible by integration"
       days: 1

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
@@ -16,8 +16,8 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Your task is to fix issues labeled for the "Resource not accessible by integration" problem.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
@@ -16,6 +16,8 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Your task is to fix issues labeled for the "Resource not accessible by integration" problem.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -16,8 +16,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Your task is to triage issues that carry the detector label `oblt-aw/detector/res-not-accessible-by-integration` and determine if they are related to "Resource not accessible by integration" errors in GitHub Actions workflows.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -16,6 +16,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Your task is to triage issues that carry the detector label `oblt-aw/detector/res-not-accessible-by-integration` and determine if they are related to "Resource not accessible by integration" errors in GitHub Actions workflows.
 

--- a/.github/workflows/gh-aw-security-fixer.yml
+++ b/.github/workflows/gh-aw-security-fixer.yml
@@ -19,8 +19,8 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Your task is to fix security issues labeled for remediation. This workflow uses agentic workflows from elastic/ai-github-actions.
 

--- a/.github/workflows/gh-aw-security-fixer.yml
+++ b/.github/workflows/gh-aw-security-fixer.yml
@@ -19,6 +19,8 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Your task is to fix security issues labeled for remediation. This workflow uses agentic workflows from elastic/ai-github-actions.
 

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -22,6 +22,8 @@ jobs:
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Your task is to triage newly opened security-related issues in this repository. Security issues include vulnerabilities in GitHub Actions workflows and shell scripts: injection (expression, command, YAML), secret management (token exposure via CLI args, secrets in command strings), supply chain (action pinning, checksums), and least privilege (excessive permissions).
 

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -22,8 +22,8 @@ jobs:
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Your task is to triage newly opened security-related issues in this repository. Security issues include vulnerabilities in GitHub Actions workflows and shell scripts: injection (expression, command, YAML), secret management (token exposure via CLI args, secrets in command strings), supply chain (action pinning, checksums), and least privilege (excessive permissions).
 


### PR DESCRIPTION
## Summary
- Pin `model: gpt-4.1` on every `gh-aw-*.yml` workflow that calls `elastic/ai-github-actions` lock workflows.
- Follow-up to #672: CI logs showed `COPILOT_MODEL=gpt-5.2-codex` while Copilot still exited with code 1 and **0B stdout/stderr** under AWF (`copilot_driver` does not retry). The gpt-5.x-codex pin did not address the failure mode.
- This change tries a non-codex model (`gpt-4.1`) that remains in the gh-aw effective-tokens multiplier list.

## Validation
- Pre-commit (yamllint, actionlint) passed on commit.

## Risks / Known Gaps
- If `gpt-4.1` fails the same way, the issue is likely AWF chroot / Copilot CLI (escalate to `github/gh-aw` or Copilot), not catalog YAML alone.

Related issue: https://github.com/elastic/observability-robots/issues/4189
