### PR TITLE
ci(gh-aw): pin ai-github-actions to v0; remove model workflow_call inputs

### DIFF
--- a/.github/workflows/gh-aw-agent-suggestions.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.yml
@@ -15,8 +15,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       title-prefix: "[oblt-aw][agent-suggestions]"
       additional-instructions: |
         Additional requirements for this repository:

--- a/.github/workflows/gh-aw-agent-suggestions.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.yml
@@ -15,6 +15,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       title-prefix: "[oblt-aw][agent-suggestions]"
       additional-instructions: |
         Additional requirements for this repository:

--- a/.github/workflows/gh-aw-agent-suggestions.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.yml
@@ -15,8 +15,6 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@v0
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       title-prefix: "[oblt-aw][agent-suggestions]"
       additional-instructions: |
         Additional requirements for this repository:

--- a/.github/workflows/gh-aw-agent-suggestions.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-agent-suggestions.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.yml
@@ -15,8 +15,6 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@main
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       title-prefix: "[oblt-aw][agent-suggestions]"
       additional-instructions: |
         Additional requirements for this repository:

--- a/.github/workflows/gh-aw-autodoc.yml
+++ b/.github/workflows/gh-aw-autodoc.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   # Step 1: Detect docs drift from recent code changes and create an issue with findings
   audit:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1
@@ -44,7 +44,7 @@ jobs:
   fix:
     needs: audit
     if: needs.audit.outputs.created_issue_number != ''
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-autodoc.yml
+++ b/.github/workflows/gh-aw-autodoc.yml
@@ -17,6 +17,8 @@ jobs:
   audit:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       lookback-window: 1 day ago
       title-prefix: "[oblt-aw][autodoc]"
       additional-instructions: |
@@ -44,6 +46,8 @@ jobs:
     if: needs.audit.outputs.created_issue_number != ''
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       target-issue-number: ${{ needs.audit.outputs.created_issue_number }}
       draft-prs: true
       additional-instructions: |

--- a/.github/workflows/gh-aw-autodoc.yml
+++ b/.github/workflows/gh-aw-autodoc.yml
@@ -17,8 +17,6 @@ jobs:
   audit:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@v0
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       lookback-window: 1 day ago
       title-prefix: "[oblt-aw][autodoc]"
       additional-instructions: |
@@ -46,8 +44,6 @@ jobs:
     if: needs.audit.outputs.created_issue_number != ''
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@v0
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       target-issue-number: ${{ needs.audit.outputs.created_issue_number }}
       draft-prs: true
       additional-instructions: |

--- a/.github/workflows/gh-aw-autodoc.yml
+++ b/.github/workflows/gh-aw-autodoc.yml
@@ -17,8 +17,8 @@ jobs:
   audit:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       lookback-window: 1 day ago
       title-prefix: "[oblt-aw][autodoc]"
       additional-instructions: |
@@ -46,8 +46,8 @@ jobs:
     if: needs.audit.outputs.created_issue_number != ''
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       target-issue-number: ${{ needs.audit.outputs.created_issue_number }}
       draft-prs: true
       additional-instructions: |

--- a/.github/workflows/gh-aw-autodoc.yml
+++ b/.github/workflows/gh-aw-autodoc.yml
@@ -17,8 +17,6 @@ jobs:
   audit:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@main
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       lookback-window: 1 day ago
       title-prefix: "[oblt-aw][autodoc]"
       additional-instructions: |
@@ -46,8 +44,6 @@ jobs:
     if: needs.audit.outputs.created_issue_number != ''
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@main
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       target-issue-number: ${{ needs.audit.outputs.created_issue_number }}
       draft-prs: true
       additional-instructions: |

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -62,6 +62,8 @@ jobs:
     if: needs.verify.outputs.proceed == 'true'
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Target pull request number: ${{ github.event.pull_request.number }}.
       prompt: |

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -62,8 +62,8 @@ jobs:
     if: needs.verify.outputs.proceed == 'true'
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Target pull request number: ${{ github.event.pull_request.number }}.
       prompt: |

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -62,8 +62,6 @@ jobs:
     if: needs.verify.outputs.proceed == 'true'
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@v0
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Target pull request number: ${{ github.event.pull_request.number }}.
       prompt: |

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -60,7 +60,7 @@ jobs:
   approve:
     needs: verify
     if: needs.verify.outputs.proceed == 'true'
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -62,8 +62,6 @@ jobs:
     if: needs.verify.outputs.proceed == 'true'
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@main
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Target pull request number: ${{ github.event.pull_request.number }}.
       prompt: |

--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -15,8 +15,6 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@main
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       allowed-bot-users: "dependabot[bot],renovate[bot],Dependabot,Renovate,elastic-vault-github-plugin-prod[bot]"
       classification-labels: "oblt-aw/ai/merge-ready"
       additional-instructions: |

--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -15,8 +15,6 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@v0
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       allowed-bot-users: "dependabot[bot],renovate[bot],Dependabot,Renovate,elastic-vault-github-plugin-prod[bot]"
       classification-labels: "oblt-aw/ai/merge-ready"
       additional-instructions: |

--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -15,8 +15,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       allowed-bot-users: "dependabot[bot],renovate[bot],Dependabot,Renovate,elastic-vault-github-plugin-prod[bot]"
       classification-labels: "oblt-aw/ai/merge-ready"
       additional-instructions: |

--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -15,6 +15,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       allowed-bot-users: "dependabot[bot],renovate[bot],Dependabot,Renovate,elastic-vault-github-plugin-prod[bot]"
       classification-labels: "oblt-aw/ai/merge-ready"
       additional-instructions: |

--- a/.github/workflows/gh-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/gh-aw-duplicate-issue-detector.yml
@@ -15,8 +15,5 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@v0
-    with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/gh-aw-duplicate-issue-detector.yml
@@ -15,8 +15,5 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@main
-    with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/gh-aw-duplicate-issue-detector.yml
@@ -15,5 +15,8 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@main
+    with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/gh-aw-duplicate-issue-detector.yml
@@ -16,7 +16,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/gh-aw-duplicate-issue-detector.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-issue-triage.yml
+++ b/.github/workflows/gh-aw-issue-triage.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-issue-triage.yml
+++ b/.github/workflows/gh-aw-issue-triage.yml
@@ -16,8 +16,5 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
-    with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-issue-triage.yml
+++ b/.github/workflows/gh-aw-issue-triage.yml
@@ -17,7 +17,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-issue-triage.yml
+++ b/.github/workflows/gh-aw-issue-triage.yml
@@ -16,5 +16,8 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
+    with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-issue-triage.yml
+++ b/.github/workflows/gh-aw-issue-triage.yml
@@ -16,8 +16,5 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
-    with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-mention-in-issue.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-mention-in-issue.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.yml
@@ -18,8 +18,5 @@ jobs:
       issues: write
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@v0
-    with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-mention-in-issue.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.yml
@@ -17,7 +17,7 @@ jobs:
       discussions: write
       issues: write
       pull-requests: write
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-mention-in-issue.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.yml
@@ -18,5 +18,8 @@ jobs:
       issues: write
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@main
+    with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-mention-in-issue.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.yml
@@ -18,8 +18,5 @@ jobs:
       issues: write
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@main
-    with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
@@ -35,6 +35,8 @@ jobs:
         workflow: ${{ fromJSON(needs.discover.outputs.workflows) }}
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-log-searching-agent.lock.yml@copilot/log-searching-agent-preflight
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       workflow: ${{ matrix.workflow }}
       search-terms: "Resource not accessible by integration"
       days: 1

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
@@ -35,8 +35,6 @@ jobs:
         workflow: ${{ fromJSON(needs.discover.outputs.workflows) }}
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-log-searching-agent.lock.yml@copilot/log-searching-agent-preflight
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       workflow: ${{ matrix.workflow }}
       search-terms: "Resource not accessible by integration"
       days: 1

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-detector.yml
@@ -35,8 +35,8 @@ jobs:
         workflow: ${{ fromJSON(needs.discover.outputs.workflows) }}
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-log-searching-agent.lock.yml@copilot/log-searching-agent-preflight
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       workflow: ${{ matrix.workflow }}
       search-terms: "Resource not accessible by integration"
       days: 1

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.label.name == 'oblt-aw/ai/fix-ready' &&
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
@@ -16,8 +16,8 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Your task is to fix issues labeled for the "Resource not accessible by integration" problem.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
@@ -16,8 +16,6 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@v0
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Your task is to fix issues labeled for the "Resource not accessible by integration" problem.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
@@ -16,6 +16,8 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Your task is to fix issues labeled for the "Resource not accessible by integration" problem.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
@@ -16,8 +16,6 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Your task is to fix issues labeled for the "Resource not accessible by integration" problem.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -16,8 +16,6 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Your task is to triage issues that carry the detector label `oblt-aw/detector/res-not-accessible-by-integration` and determine if they are related to "Resource not accessible by integration" errors in GitHub Actions workflows.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -16,8 +16,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Your task is to triage issues that carry the detector label `oblt-aw/detector/res-not-accessible-by-integration` and determine if they are related to "Resource not accessible by integration" errors in GitHub Actions workflows.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -16,8 +16,6 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Your task is to triage issues that carry the detector label `oblt-aw/detector/res-not-accessible-by-integration` and determine if they are related to "Resource not accessible by integration" errors in GitHub Actions workflows.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -16,6 +16,8 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Your task is to triage issues that carry the detector label `oblt-aw/detector/res-not-accessible-by-integration` and determine if they are related to "Resource not accessible by integration" errors in GitHub Actions workflows.
 

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-security-fixer.yml
+++ b/.github/workflows/gh-aw-security-fixer.yml
@@ -19,8 +19,6 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Your task is to fix security issues labeled for remediation. This workflow uses agentic workflows from elastic/ai-github-actions.
 

--- a/.github/workflows/gh-aw-security-fixer.yml
+++ b/.github/workflows/gh-aw-security-fixer.yml
@@ -19,8 +19,8 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Your task is to fix security issues labeled for remediation. This workflow uses agentic workflows from elastic/ai-github-actions.
 

--- a/.github/workflows/gh-aw-security-fixer.yml
+++ b/.github/workflows/gh-aw-security-fixer.yml
@@ -19,6 +19,8 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Your task is to fix security issues labeled for remediation. This workflow uses agentic workflows from elastic/ai-github-actions.
 

--- a/.github/workflows/gh-aw-security-fixer.yml
+++ b/.github/workflows/gh-aw-security-fixer.yml
@@ -17,7 +17,7 @@ jobs:
     if: >-
       github.event.label.name == 'oblt-aw/ai/fix-ready' &&
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-security-fixer.yml
+++ b/.github/workflows/gh-aw-security-fixer.yml
@@ -19,8 +19,6 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@v0
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Your task is to fix security issues labeled for remediation. This workflow uses agentic workflows from elastic/ai-github-actions.
 

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -20,7 +20,7 @@ jobs:
       discussions: write
       issues: write
       pull-requests: write
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
     with:
       # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
       model: gpt-4.1

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -22,8 +22,6 @@ jobs:
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Your task is to triage newly opened security-related issues in this repository. Security issues include vulnerabilities in GitHub Actions workflows and shell scripts: injection (expression, command, YAML), secret management (token exposure via CLI args, secrets in command strings), supply chain (action pinning, checksums), and least privilege (excessive permissions).
 

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -22,6 +22,8 @@ jobs:
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
+      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
+      model: gpt-5.2-codex
       additional-instructions: |
         Your task is to triage newly opened security-related issues in this repository. Security issues include vulnerabilities in GitHub Actions workflows and shell scripts: injection (expression, command, YAML), secret management (token exposure via CLI args, secrets in command strings), supply chain (action pinning, checksums), and least privilege (excessive permissions).
 

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -22,8 +22,8 @@ jobs:
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
-      # Avoid lock default gpt-5.3-codex: silent exit 1 under AWF (no driver retry).
-      model: gpt-5.2-codex
+      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
+      model: gpt-4.1
       additional-instructions: |
         Your task is to triage newly opened security-related issues in this repository. Security issues include vulnerabilities in GitHub Actions workflows and shell scripts: injection (expression, command, YAML), secret management (token exposure via CLI args, secrets in command strings), supply chain (action pinning, checksums), and least privilege (excessive permissions).
 

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -22,8 +22,6 @@ jobs:
       pull-requests: write
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
-      # AWF: gpt-5.x-codex exits with code 1 and no stdout/stderr; pin gpt-4.1 until upstream fix.
-      model: gpt-4.1
       additional-instructions: |
         Your task is to triage newly opened security-related issues in this repository. Security issues include vulnerabilities in GitHub Actions workflows and shell scripts: injection (expression, command, YAML), secret management (token exposure via CLI args, secrets in command strings), supply chain (action pinning, checksums), and least privilege (excessive permissions).
 


### PR DESCRIPTION
## Summary

- Pin every `elastic/ai-github-actions` reusable workflow reference used by `gh-aw-*.yml` callers from `@main` to **`@v0`**.
- **Remove the `model` `workflow_call` input** from all `gh-aw-*` wrappers that delegate to those lock workflows (drop empty `with:` blocks where `model` was the only input). Callers no longer pass an explicit model so Copilot CLI avoids startup validation that can fail with classic PATs when `COPILOT_MODEL` is set; see [github/gh-aw#25593](https://github.com/github/gh-aw/issues/25593). Lock workflows keep their own defaults upstream.

## Validation

- Pre-commit (yamllint, workflow lint) passed on commit.
- PyYAML parse check on all `gh-aw-*.yml` workflows.

## Risks / known gaps

- Tag **`v0`** on `elastic/ai-github-actions` must include the referenced `.lock.yml` paths.
- Behavior for Copilot model selection now follows upstream lock defaults and runtime environment.

Related issue: https://github.com/elastic/observability-robots/issues/4189
