### PR TITLE
chore(workflows): pin gh-aw lock workflows to ai-github-actions main

### DIFF
--- a/.github/workflows/gh-aw-agent-suggestions.yml
+++ b/.github/workflows/gh-aw-agent-suggestions.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@main
     with:
       title-prefix: "[oblt-aw][agent-suggestions]"
       additional-instructions: |

--- a/.github/workflows/gh-aw-autodoc.yml
+++ b/.github/workflows/gh-aw-autodoc.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   # Step 1: Detect docs drift from recent code changes and create an issue with findings
   audit:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@main
     with:
       lookback-window: 1 day ago
       title-prefix: "[oblt-aw][autodoc]"
@@ -42,7 +42,7 @@ jobs:
   fix:
     needs: audit
     if: needs.audit.outputs.created_issue_number != ''
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-create-pr-from-issue.lock.yml@main
     with:
       target-issue-number: ${{ needs.audit.outputs.created_issue_number }}
       draft-prs: true

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -60,7 +60,7 @@ jobs:
   approve:
     needs: verify
     if: needs.verify.outputs.proceed == 'true'
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@main
     with:
       additional-instructions: |
         Target pull request number: ${{ github.event.pull_request.number }}.

--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@main
     with:
       allowed-bot-users: "dependabot[bot],renovate[bot],Dependabot,Renovate,elastic-vault-github-plugin-prod[bot]"
       classification-labels: "oblt-aw/ai/merge-ready"

--- a/.github/workflows/gh-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/gh-aw-duplicate-issue-detector.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@main
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-issue-triage.yml
+++ b/.github/workflows/gh-aw-issue-triage.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-mention-in-issue.yml
+++ b/.github/workflows/gh-aw-mention-in-issue.yml
@@ -17,6 +17,6 @@ jobs:
       discussions: write
       issues: write
       pull-requests: write
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@main
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-fixer.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.label.name == 'oblt-aw/ai/fix-ready' &&
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
       additional-instructions: |
         Your task is to fix issues labeled for the "Resource not accessible by integration" problem.

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
       additional-instructions: |
         Your task is to triage issues that carry the detector label `oblt-aw/detector/res-not-accessible-by-integration` and determine if they are related to "Resource not accessible by integration" errors in GitHub Actions workflows.

--- a/.github/workflows/gh-aw-security-fixer.yml
+++ b/.github/workflows/gh-aw-security-fixer.yml
@@ -17,7 +17,7 @@ jobs:
     if: >-
       github.event.label.name == 'oblt-aw/ai/fix-ready' &&
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
       additional-instructions: |
         Your task is to fix security issues labeled for remediation. This workflow uses agentic workflows from elastic/ai-github-actions.

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -20,7 +20,7 @@ jobs:
       discussions: write
       issues: write
       pull-requests: write
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
       additional-instructions: |
         Your task is to triage newly opened security-related issues in this repository. Security issues include vulnerabilities in GitHub Actions workflows and shell scripts: injection (expression, command, YAML), secret management (token exposure via CLI args, secrets in command strings), supply chain (action pinning, checksums), and least privilege (excessive permissions).


### PR DESCRIPTION
## Summary
- Point all `workflow_call` usages of `elastic/ai-github-actions` `gh-aw-*.lock.yml` workflows from tag `v0` to branch `main` (11 workflow files, 12 `uses:` lines).

## Validation
- Pre-commit hooks on commit: yamllint, GitHub Actions workflow lint, and other configured hooks passed.

## Risks / Known Gaps
- Pinning to `main` follows the latest lockfile revisions but can introduce churn when upstream changes; consider returning to a release tag once a suitable tag includes the desired lockfile behavior.

Fixes https://github.com/elastic/observability-github-settings/actions/runs/24393652286/job/71246499794
Related issue: https://github.com/elastic/observability-robots/issues/3614
