### PR TITLE
fix(workflows): gate merge-queue fallback on automerge mergeResult

### DIFF
--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -100,6 +100,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      merge_result: ${{ steps.merge-pull-request.outputs.mergeResult }}
     steps:
       - id: merge-pull-request
         name: Merge pull request when ready (squash)
@@ -121,7 +123,7 @@ jobs:
   # Do not pass --delete-branch here: gh rejects it when merge queue is enabled.
   enable-merge-when-ready:
     needs: automerge
-    if: always() && needs.automerge.result == 'failure'
+    if: always() && needs.automerge.outputs.merge_result == 'merge_failed'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Summary

- Follow-up to #696: gate `enable-merge-when-ready` on **pascalgn/automerge-action** output **`mergeResult`** (job output `merge_result` equals `merge_failed`) instead of **`needs.automerge.result == 'failure'`**.
- Avoids relying on `MERGE_ERROR_FAIL` or a failed automerge job: when REST merge fails (e.g. merge queue rules), the action still exits successfully with `merge_failed`, and the fallback can run.

## Validation

- Pre-commit hooks: yamllint, actionlint, YAML checks passed locally.

## Risks / Known Gaps

- Fallback runs only when `merge_result == merge_failed`. If the automerge job fails before outputs are set, the fallback does not run.

Related issue: https://github.com/elastic/observability-robots/issues/3849
