### PR TITLE
fix(workflows): ephemeral token for merge-when-ready fallback

### DIFF
--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -115,7 +115,7 @@ jobs:
           MERGE_FORKS: "false"
           MERGE_DELETE_BRANCH: "true"
           MERGE_REQUIRED_APPROVALS: "1"
-          MERGE_RETRIES: "30"
+          MERGE_RETRIES: "10"
           MERGE_RETRY_SLEEP: "20000"
 
   # pascalgn/automerge-action uses the REST merge API, which branch rules can reject when

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -100,6 +100,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      merge_result: ${{ steps.merge-pull-request.outputs.mergeResult }}
     steps:
       - id: merge-pull-request
         name: Merge pull request when ready (squash)
@@ -121,7 +123,7 @@ jobs:
   # Do not pass --delete-branch here: gh rejects it when merge queue is enabled.
   enable-merge-when-ready:
     needs: automerge
-    if: always() && needs.automerge.result == 'failure'
+    if: always() && needs.automerge.outputs.merge_result == 'merge_failed'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -127,12 +127,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: write
-      pull-requests: write
+      id-token: write
     steps:
+      - name: Create ephemeral GitHub token
+        id: create-token
+        uses: elastic/oblt-actions/github/create-token@v1
+        with:
+          token-policy: token-policy-5a5dcea1ee13
+
       - name: Enable merge when ready (merge queue fallback)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.create-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |


### PR DESCRIPTION
## Summary

When `pascalgn/automerge-action` reports `merge_failed` (for example because merge queue blocks the REST merge path), the `enable-merge-when-ready` job runs `gh pr merge --auto --squash` as a fallback.

This change switches that step from `GITHUB_TOKEN` to an ephemeral token from `elastic/oblt-actions/github/create-token@v1` using token policy `token-policy-5a5dcea1ee13`, with job permissions narrowed to `id-token: write` for OIDC.

Needs https://github.com/elastic/catalog-info/pull/3686

## Validation

- Pre-commit hooks (yamllint, actionlint) passed on commit.