### PR TITLE
ci(workflows): load-allowed-pr-authors job id and log outputs

### DIFF
--- a/.github/workflows/load-allowed-pr-authors.yml
+++ b/.github/workflows/load-allowed-pr-authors.yml
@@ -9,16 +9,16 @@ on:
     outputs:
       allowed_pr_authors_json:
         description: Compact JSON array string of allowed GitHub logins for ingress if conditions
-        value: ${{ jobs.load.outputs.allowed_pr_authors_json }}
+        value: ${{ jobs.load-allowed-pr-authors.outputs.allowed_pr_authors_json }}
       allowed_pr_authors_csv:
         description: Same logins comma-separated (for allowed-bot-users-style inputs)
-        value: ${{ jobs.load.outputs.allowed_pr_authors_csv }}
+        value: ${{ jobs.load-allowed-pr-authors.outputs.allowed_pr_authors_csv }}
 
 permissions:
   contents: read
 
 jobs:
-  load:
+  load-allowed-pr-authors:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     outputs:
@@ -46,3 +46,12 @@ jobs:
           CSV=$(jq -r 'join(",")' "${FILE}")
           echo "allowed_pr_authors_json=$JSON" >> "${GITHUB_OUTPUT}"
           echo "allowed_pr_authors_csv=$CSV" >> "${GITHUB_OUTPUT}"
+
+      - name: Print loaded allow list
+        env:
+          ALLOWED_PR_AUTHORS_JSON: ${{ steps.pack.outputs.allowed_pr_authors_json }}
+          ALLOWED_PR_AUTHORS_CSV: ${{ steps.pack.outputs.allowed_pr_authors_csv }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "allowed_pr_authors_json:" "${ALLOWED_PR_AUTHORS_JSON}"
+          printf '%s\n' "allowed_pr_authors_csv:" "${ALLOWED_PR_AUTHORS_CSV}"


### PR DESCRIPTION
## Summary
- Renamed the reusable workflow job id from `load` to `load-allowed-pr-authors` and updated `workflow_call` output expressions to reference the new job id.
- Added a `Print loaded allow list` step after packing so CI logs show the compact JSON array and CSV derived from `allowed_pr_authors.json` (values passed through `env:` and `printf` for shell-safe output).

## Validation
- Pre-commit hooks on commit: `yamllint`, action/workflow linters, and YAML checks passed locally.

## Risks / Known gaps
- Logs include the full allow list on every run; that is public configuration from `elastic/oblt-aw` but increases log verbosity slightly.

Related issue: https://github.com/elastic/observability-robots/issues/4189
