### PR TITLE
ci: ephemeral token and classification-labels for specialized issue triage

### DIFF
--- a/.github/workflows/gh-aw-issue-triage.yml
+++ b/.github/workflows/gh-aw-issue-triage.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  run:
+  issue-triage:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -5,17 +5,38 @@ on:
       COPILOT_GITHUB_TOKEN:
         required: true
 
+# Ephemeral installation token for GH-AW label/issue API so follow-on workflows are not suppressed
+# (GITHUB_TOKEN mutations do not trigger other workflows). Omit token-policy so Vault uses the
+# auto role token-policy-<12-char sha256(workflow ref base)> for this workflow file; register it in catalog-info.
 permissions:
   actions: read
   contents: read
-  discussions: write
-  issues: write
-  pull-requests: write
 
 jobs:
-  run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
+  mint-gh-aw-github-token:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      token: ${{ steps.create-token.outputs.token }}
+    steps:
+      - name: Create ephemeral GitHub token
+        id: create-token
+        uses: elastic/oblt-actions/github/create-token@v1
+
+  res-not-accessible-integration-triage:
+    needs: mint-gh-aw-github-token
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
+    # Ref tracks elastic/ai-github-actions PR (classification-labels + GH_AW_GITHUB_TOKEN on workflow_call); switch to @main after merge.
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@copilot/add-classification-labels-input
     with:
+      classification-labels: "oblt-aw/triage/res-not-accessible-by-integration,oblt-aw/triage/other,oblt-aw/triage/needs-info,oblt-aw/ai/fix-ready"
       additional-instructions: |
         Your task is to triage issues that carry the detector label `oblt-aw/detector/res-not-accessible-by-integration` and determine if they are related to "Resource not accessible by integration" errors in GitHub Actions workflows.
 
@@ -200,4 +221,6 @@ jobs:
         - [GitHub Actions Permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
         - [Workflow Permission Syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
         - [Troubleshooting Permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
-    secrets: inherit
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GH_AW_GITHUB_TOKEN: ${{ needs.mint-gh-aw-github-token.outputs.token }}

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -5,23 +5,38 @@ on:
       COPILOT_GITHUB_TOKEN:
         required: true
 
+# Ephemeral installation token for GH-AW label/issue API so follow-on workflows are not suppressed
+# (GITHUB_TOKEN mutations do not trigger other workflows). Omit token-policy so Vault uses the
+# auto role token-policy-<12-char sha256(workflow ref base)> for this workflow file; register it in catalog-info.
 permissions:
   actions: read
   contents: read
-  discussions: read
-  issues: read
-  pull-requests: read
 
 jobs:
-  run:
+  mint-gh-aw-github-token:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      token: ${{ steps.create-token.outputs.token }}
+    steps:
+      - name: Create ephemeral GitHub token
+        id: create-token
+        uses: elastic/oblt-actions/github/create-token@v1
+
+  security-issue-triage:
+    needs: mint-gh-aw-github-token
     permissions:
       actions: read
       contents: read
       discussions: write
       issues: write
       pull-requests: write
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
+    # Ref tracks elastic/ai-github-actions PR (classification-labels + GH_AW_GITHUB_TOKEN on workflow_call); switch to @main after merge.
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@copilot/add-classification-labels-input
     with:
+      classification-labels: "oblt-aw/triage/security-injection,oblt-aw/triage/security-secrets,oblt-aw/triage/security-supply-chain,oblt-aw/triage/security-least-privilege,oblt-aw/triage/other,oblt-aw/triage/needs-info,oblt-aw/ai/fix-ready"
       additional-instructions: |
         Your task is to triage newly opened security-related issues in this repository. Security issues include vulnerabilities in GitHub Actions workflows and shell scripts: injection (expression, command, YAML), secret management (token exposure via CLI args, secrets in command strings), supply chain (action pinning, checksums), and least privilege (excessive permissions).
 
@@ -96,4 +111,6 @@ jobs:
         ### Additional Resources
         - [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
         - [Workflow Permission Syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
-    secrets: inherit
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GH_AW_GITHUB_TOKEN: ${{ needs.mint-gh-aw-github-token.outputs.token }}

--- a/docs/workflows/gh-aw-issue-triage.md
+++ b/docs/workflows/gh-aw-issue-triage.md
@@ -18,7 +18,7 @@ Ingress routes here when:
 - `github.event_name == 'issues'` and `github.event.action == 'opened'`, and
 - Dashboard gating allows `issue-triage` (or no dashboard issue is present, so all workflows are enabled).
 
-The job `run` calls:
+The job `issue-triage` calls:
 
 - [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main](https://github.com/elastic/ai-github-actions/blob/main/.github/workflows/gh-aw-issue-triage.lock.yml)
 

--- a/docs/workflows/gh-aw-resource-not-accessible-by-integration-triage.md
+++ b/docs/workflows/gh-aw-resource-not-accessible-by-integration-triage.md
@@ -10,12 +10,15 @@ This reusable workflow triages issues that carry the detector label `oblt-aw/det
 
 - Triggered via `workflow_call`.
 - Required secret: `COPILOT_GITHUB_TOKEN`.
+- **Job `mint-gh-aw-github-token`:** `contents: read`, `id-token: write` (OIDC for ephemeral `create-token` with no explicit `token-policy`; catalog-info auto role for this workflow file).
 
 ## Usage
 
-The job `run` calls:
+The job `mint-gh-aw-github-token` mints an installation token via [`elastic/oblt-actions/github/create-token@v1`](https://github.com/elastic/oblt-actions/tree/v1/github/create-token). The job `res-not-accessible-integration-triage` calls:
 
-- [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main](https://github.com/elastic/ai-github-actions/blob/main/.github/workflows/gh-aw-issue-triage.lock.yml)
+- [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@copilot/add-classification-labels-input](https://github.com/elastic/ai-github-actions/blob/copilot/add-classification-labels-input/.github/workflows/gh-aw-issue-triage.lock.yml) (switch to `@main` after upstream merge)
+
+The nested workflow receives **`GH_AW_GITHUB_TOKEN`** (mint output) and **`classification-labels`** for `oblt-aw/triage/res-not-accessible-by-integration`, `oblt-aw/triage/other`, `oblt-aw/triage/needs-info`, and `oblt-aw/ai/fix-ready`.
 
 Configured instructions define:
 
@@ -28,11 +31,9 @@ Configured instructions define:
 
 Permissions:
 
-- `actions: read`
-- `contents: read`
-- `discussions: write`
-- `issues: write`
-- `pull-requests: write`
+- **Workflow default:** `actions: read`, `contents: read`
+- **Job `mint-gh-aw-github-token`:** `contents: read`, `id-token: write`
+- **Job `res-not-accessible-integration-triage`:** `actions: read`, `contents: read`, `discussions: write`, `issues: write`, `pull-requests: write`
 
 ## API / Interface
 

--- a/docs/workflows/gh-aw-security-triage.md
+++ b/docs/workflows/gh-aw-security-triage.md
@@ -10,12 +10,15 @@ This reusable workflow triages newly opened security-related issues and prepares
 
 - Triggered via `workflow_call`.
 - Required secret: `COPILOT_GITHUB_TOKEN`.
+- **Job `mint-gh-aw-github-token`:** `contents: read`, `id-token: write` (OIDC for ephemeral `create-token` with no explicit `token-policy`; catalog-info auto role for this workflow file).
 
 ## Usage
 
-The job `run` calls:
+The job `mint-gh-aw-github-token` mints an installation token via [`elastic/oblt-actions/github/create-token@v1`](https://github.com/elastic/oblt-actions/tree/v1/github/create-token). The job `security-issue-triage` calls:
 
-- [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main](https://github.com/elastic/ai-github-actions/blob/main/.github/workflows/gh-aw-issue-triage.lock.yml)
+- [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@copilot/add-classification-labels-input](https://github.com/elastic/ai-github-actions/blob/copilot/add-classification-labels-input/.github/workflows/gh-aw-issue-triage.lock.yml) (switch to `@main` after upstream merge)
+
+The nested workflow receives **`GH_AW_GITHUB_TOKEN`** (mint output) for GitHub API mutations and **`classification-labels`** matching the security triage allowlist below.
 
 Configured instructions define:
 
@@ -26,10 +29,11 @@ Configured instructions define:
 
 ## Configuration
 
-Permissions follow a read-only workflow default with writes confined to the `run` job (same pattern as `gh-aw-security-detector.yml`):
+Permissions:
 
-- **Workflow:** `actions`, `contents`, `discussions`, `issues`, and `pull-requests` are `read` only.
-- **Job `run`:** `actions: read`, `contents: read`, `discussions: write`, `issues: write`, `pull-requests: write` (minimum needed for issue triage and the nested lock workflow).
+- **Workflow default:** `actions: read`, `contents: read`
+- **Job `mint-gh-aw-github-token`:** `contents: read`, `id-token: write`
+- **Job `security-issue-triage`:** `actions: read`, `contents: read`, `discussions: write`, `issues: write`, `pull-requests: write`
 
 ## API / Interface
 


### PR DESCRIPTION
## Summary

- Add a `mint-gh-aw-github-token` job to **security issue triage** and **resource-not-accessible-by-integration triage** using `elastic/oblt-actions/github/create-token@v1` without an explicit token policy (OIDC auto role for this workflow file).
- Pass the minted token to `gh-aw-issue-triage.lock.yml` as **`GH_AW_GITHUB_TOKEN`** so label and comment actions use an installation token rather than `GITHUB_TOKEN`, allowing follow-on workflows to run.
- Pass **`classification-labels`** allowlists aligned with each workflow’s instructions (security triage labels plus `oblt-aw/ai/fix-ready`; resource triage labels plus `oblt-aw/ai/fix-ready`).
- Pin the lock workflow to **`elastic/ai-github-actions` branch `copilot/add-classification-labels-input`** until that contract ships on `main`.
- Leave **`gh-aw-issue-triage.yml`** as a thin wrapper on **`@main`** with only `COPILOT_GITHUB_TOKEN`; refresh **`docs/workflows/gh-aw-issue-triage.md`** accordingly.

## Validation

- Repository `pre-commit` hooks (yamllint, actionlint, and so on) passed on commit.

## Risks / follow-ups

- Consumers need the ephemeral token policy registered in catalog-info for these workflow files if not already present.
- After upstream merges the classification-labels and optional secret contract to `main`, update the `uses:` ref from the feature branch to `@main`.

Related issue: https://github.com/elastic/observability-robots/issues/3863
