### PR TITLE
fix(ci): trigger security-fixer regardless of label order

### DIFF
--- a/.github/workflows/gh-aw-security-fixer.yml
+++ b/.github/workflows/gh-aw-security-fixer.yml
@@ -19,9 +19,6 @@ permissions:
 
 jobs:
   security-issue-fixer:
-    if: >-
-      github.event.label.name == 'oblt-aw/ai/fix-ready' &&
-      contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
       allowed-bot-users: ${{ inputs.allowed-bot-users }}

--- a/.github/workflows/oblt-aw-ingress.yml
+++ b/.github/workflows/oblt-aw-ingress.yml
@@ -166,8 +166,10 @@ jobs:
     if: >-
       github.event_name == 'issues' &&
       github.event.action == 'labeled' &&
-      github.event.label.name == 'oblt-aw/ai/fix-ready' &&
-      contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-') &&
+      (
+        (github.event.label.name == 'oblt-aw/ai/fix-ready' && contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')) ||
+        (startsWith(github.event.label.name, 'oblt-aw/triage/security-') && contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/ai/fix-ready'))
+      ) &&
       (needs['dashboard-enabled-workflows'].outputs['effective-raw'] == '' || contains(fromJSON(needs['dashboard-enabled-workflows'].outputs['enabled-workflows']), 'obs:security'))
     uses: ./.github/workflows/gh-aw-security-fixer.yml
     with:


### PR DESCRIPTION
## Summary

- **Ingress:** Run `security-fixer` when either `oblt-aw/ai/fix-ready` or a label whose name starts with `oblt-aw/triage/security-` triggers `issues` `labeled`, as long as the issue already has the other required label. That covers both label orders (one `labeled` event per label).
- **Wrapper:** Remove the duplicate job-level `if` from `gh-aw-security-fixer.yml`; ingress is the single gate.

## Validation

- Local pre-commit on commit: yamllint, actionlint, and related hooks passed.

## Risks

- Any future caller of `gh-aw-security-fixer.yml` without the ingress predicates would no longer get the inner guard (only `workflow_call` from ingress today).

Related issue: https://github.com/elastic/observability-robots/issues/3820
