### PR TITLE
chore(ci): point gh-aw issue triage workflows at ai-github-actions@main

### DIFF
--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -38,8 +38,7 @@ jobs:
       discussions: write
       issues: write
       pull-requests: write
-    # Ref tracks elastic/ai-github-actions PR (classification-labels + GH_AW_GITHUB_TOKEN on workflow_call); switch to @main after merge.
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@copilot/add-classification-labels-input
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
       allowed-bot-users: ${{ inputs.allowed-bot-users }}
       classification-labels: "oblt-aw/triage/res-not-accessible-by-integration,oblt-aw/triage/other,oblt-aw/triage/needs-info,oblt-aw/ai/fix-ready"

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -37,8 +37,7 @@ jobs:
       discussions: write
       issues: write
       pull-requests: write
-    # Ref tracks elastic/ai-github-actions PR (classification-labels + GH_AW_GITHUB_TOKEN on workflow_call); switch to @main after merge.
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@copilot/add-classification-labels-input
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
       allowed-bot-users: ${{ inputs.allowed-bot-users }}
       classification-labels: "oblt-aw/triage/security-injection,oblt-aw/triage/security-secrets,oblt-aw/triage/security-supply-chain,oblt-aw/triage/security-least-privilege,oblt-aw/triage/other,oblt-aw/triage/needs-info,oblt-aw/ai/fix-ready"

--- a/docs/workflows/gh-aw-resource-not-accessible-by-integration-triage.md
+++ b/docs/workflows/gh-aw-resource-not-accessible-by-integration-triage.md
@@ -16,7 +16,7 @@ This reusable workflow triages issues that carry the detector label `oblt-aw/det
 
 The job `mint-gh-aw-github-token` mints an installation token via [`elastic/oblt-actions/github/create-token@v1`](https://github.com/elastic/oblt-actions/tree/v1/github/create-token). The job `res-not-accessible-integration-triage` calls:
 
-- [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@copilot/add-classification-labels-input](https://github.com/elastic/ai-github-actions/blob/copilot/add-classification-labels-input/.github/workflows/gh-aw-issue-triage.lock.yml) (switch to `@main` after upstream merge)
+- [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main](https://github.com/elastic/ai-github-actions/blob/main/.github/workflows/gh-aw-issue-triage.lock.yml)
 
 The nested workflow receives **`GH_AW_GITHUB_TOKEN`** (mint output) and **`classification-labels`** for `oblt-aw/triage/res-not-accessible-by-integration`, `oblt-aw/triage/other`, `oblt-aw/triage/needs-info`, and `oblt-aw/ai/fix-ready`.
 

--- a/docs/workflows/gh-aw-security-triage.md
+++ b/docs/workflows/gh-aw-security-triage.md
@@ -16,7 +16,7 @@ This reusable workflow triages newly opened security-related issues and prepares
 
 The job `mint-gh-aw-github-token` mints an installation token via [`elastic/oblt-actions/github/create-token@v1`](https://github.com/elastic/oblt-actions/tree/v1/github/create-token). The job `security-issue-triage` calls:
 
-- [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@copilot/add-classification-labels-input](https://github.com/elastic/ai-github-actions/blob/copilot/add-classification-labels-input/.github/workflows/gh-aw-issue-triage.lock.yml) (switch to `@main` after upstream merge)
+- [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main](https://github.com/elastic/ai-github-actions/blob/main/.github/workflows/gh-aw-issue-triage.lock.yml)
 
 The nested workflow receives **`GH_AW_GITHUB_TOKEN`** (mint output) for GitHub API mutations and **`classification-labels`** matching the security triage allowlist below.
 


### PR DESCRIPTION
## Summary

Point the nested GitHub Agentic issue triage workflows at `elastic/ai-github-actions` on `@main` instead of the temporary `copilot/add-classification-labels-input` branch. Documentation links are updated to match.

## Validation

- Local pre-commit hooks passed on commit (yamllint, actionlint, etc.).

## Risks

- `uses: ...@main` tracks the moving head of upstream; pin to a SHA later if you need stricter reproducibility.

Related issue: https://github.com/elastic/observability-robots/issues/3863
