### PR TITLE
fix(obs): vault GitHub App PR author and author debug in load-allowed-authors

### DIFF
--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -83,7 +83,7 @@ jobs:
         Do not call check-run or commit status APIs. Required checks are enforced by GitHub when auto-merge is enabled.
 
         Approve the PR only when all of these gates are true:
-        - PR author is one of: dependabot[bot], renovate[bot], Dependabot, Renovate, elastic-vault-github-plugin-prod[bot]
+        - PR author is one of: dependabot[bot], renovate[bot], Dependabot, Renovate, elastic-vault-github-plugin-prod[bot], app/elastic-vault-github-plugin-prod
         - PR has label `oblt-aw/ai/merge-ready`
         - PR is not draft
         - PR is not from a fork (head repo equals base repo)

--- a/.github/workflows/load-allowed-authors.yml
+++ b/.github/workflows/load-allowed-authors.yml
@@ -75,3 +75,19 @@ jobs:
           printf '%s\n' "allowed_pr_authors_csv:" "${ALLOWED_PR_AUTHORS_CSV}"
           printf '%s\n' "allowed_issue_authors_json:" "${ALLOWED_ISSUE_AUTHORS_JSON}"
           printf '%s\n' "allowed_issue_authors_csv:" "${ALLOWED_ISSUE_AUTHORS_CSV}"
+
+      - name: Print triggering author (debug)
+        run: |
+          set -euo pipefail
+          printf '%s\n' "debug: github.event_name=${{ github.event_name }}"
+          case "${{ github.event_name }}" in
+            pull_request)
+              printf '%s\n' "debug: github.event.pull_request.user.login=${{ github.event.pull_request.user.login }}"
+              ;;
+            issues)
+              printf '%s\n' "debug: github.event.issue.user.login=${{ github.event.issue.user.login }}"
+              ;;
+            *)
+              printf '%s\n' "debug: no pull_request/issue author for this event"
+              ;;
+          esac

--- a/config/obs/allowed_pr_authors.json
+++ b/config/obs/allowed_pr_authors.json
@@ -3,5 +3,6 @@
   "renovate[bot]",
   "Dependabot",
   "Renovate",
-  "elastic-vault-github-plugin-prod[bot]"
+  "elastic-vault-github-plugin-prod[bot]",
+  "app/elastic-vault-github-plugin-prod"
 ]

--- a/tests/unit/validateAutomergePr.test.ts
+++ b/tests/unit/validateAutomergePr.test.ts
@@ -140,3 +140,21 @@ test('validateAutomergePr allows elastic-vault-github-plugin-prod[bot]', async (
   });
   assert.equal(r.ok, true);
 });
+
+test('validateAutomergePr allows app/elastic-vault-github-plugin-prod', async () => {
+  const { core } = makeCore();
+  const github = {
+    rest: {
+      pulls: {
+        get: async () => ({ data: basePr({ user: { login: 'app/elastic-vault-github-plugin-prod' } }) }),
+      },
+    },
+  };
+  const r = await run({
+    github,
+    context: { repo: { owner: 'elastic', repo: 'r' } },
+    prNumber: 8,
+    core,
+  });
+  assert.equal(r.ok, true);
+});


### PR DESCRIPTION
## Summary

- Add `app/elastic-vault-github-plugin-prod` to the Observability PR author allow list so ingress gates for automerge and dependency-review match `github.event.pull_request.user.login` for vault-plugin PRs.
- Update the automerge Copilot approval prompt and add a unit test for the new login.
- After printing loaded allow lists, `load-allowed-authors` now logs the triggering PR or issue author (`debug:` lines) so allow-list mismatches are easier to diagnose in job logs.

Tries to fix the automerge skipped status, for example https://github.com/elastic/observability-github-settings/pull/391

## Validation

- `npx tsx --test tests/unit/validateAutomergePr.test.ts` (all tests passed).
- Pre-commit hooks passed on both commits.

## Risks

- Slightly broadens the explicit bot login set for PR-gated workflows; the new value is the same GitHub App actor already represented as `elastic-vault-github-plugin-prod[bot]` in some contexts.

Related issue: https://github.com/elastic/observability-robots/issues/3849
