### PR TITLE
fix(workflows): keep minted GitHub token valid for nested GH-AW jobs

### DIFF
--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Create ephemeral GitHub token
         id: create-token
         uses: elastic/oblt-actions/github/create-token@v1
+        with:
+          # Default fetch-github-token revokes the installation token in a post step when Vault
+          # issues a lease. That runs when this job finishes, before the nested ai-github-actions
+          # workflow applies labels via safe_outputs — the forwarded secret is then invalid and
+          # labeling falls back to GITHUB_TOKEN (github-actions actor; no follow-on workflows).
+          skip-token-revoke: 'true'
 
   dependency-review:
     needs: mint-gh-aw-github-token

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Create ephemeral GitHub token
         id: create-token
         uses: elastic/oblt-actions/github/create-token@v1
+        with:
+          # See gh-aw-dependency-review.yml: avoid revoking the token when the mint job ends while a
+          # sibling job still forwards it to elastic/ai-github-actions for PR/issue API writes.
+          skip-token-revoke: 'true'
 
   res-not-accessible-integration-triage:
     needs: mint-gh-aw-github-token

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Create ephemeral GitHub token
         id: create-token
         uses: elastic/oblt-actions/github/create-token@v1
+        with:
+          # See gh-aw-dependency-review.yml: avoid revoking the token when the mint job ends while a
+          # sibling job still forwards it to elastic/ai-github-actions for PR/issue API writes.
+          skip-token-revoke: 'true'
 
   security-issue-triage:
     needs: mint-gh-aw-github-token

--- a/docs/workflows/gh-aw-dependency-review.md
+++ b/docs/workflows/gh-aw-dependency-review.md
@@ -38,7 +38,7 @@ Labeling semantics (in additional-instructions):
 Permissions:
 
 - **Workflow:** `actions: read`, `contents: read`.
-- **Job `mint-gh-aw-github-token`:** `contents: read`, `id-token: write` (OIDC for ephemeral `create-token`).
+- **Job `mint-gh-aw-github-token`:** `contents: read`, `id-token: write` (OIDC for ephemeral `create-token`). `create-token` is called with `skip-token-revoke: true` so Vault-backed installation tokens are **not** revoked when the mint job finishes; otherwise the default post-step revocation invalidates the token before the nested `elastic/ai-github-actions` job runs `safe_outputs` (labels/comments), and GitHub falls back to `GITHUB_TOKEN` (no follow-on workflows from labeling).
 - **Job `dependency-review`:** `actions: read`, `contents: read`, `issues: write`, `pull-requests: write`.
 
 ## API / Interface

--- a/docs/workflows/gh-aw-resource-not-accessible-by-integration-triage.md
+++ b/docs/workflows/gh-aw-resource-not-accessible-by-integration-triage.md
@@ -14,7 +14,7 @@ This reusable workflow triages issues that carry the detector label `oblt-aw/det
 
 ## Usage
 
-The job `mint-gh-aw-github-token` mints an installation token via [`elastic/oblt-actions/github/create-token@v1`](https://github.com/elastic/oblt-actions/tree/v1/github/create-token). The job `res-not-accessible-integration-triage` calls:
+The job `mint-gh-aw-github-token` mints an installation token via [`elastic/oblt-actions/github/create-token@v1`](https://github.com/elastic/oblt-actions/tree/v1/github/create-token) with `skip-token-revoke: true` so the token is not revoked at mint job completion before the nested ai-github-actions workflow uses it (see [gh-aw-dependency-review.md](gh-aw-dependency-review.md) configuration). The job `res-not-accessible-integration-triage` calls:
 
 - [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main](https://github.com/elastic/ai-github-actions/blob/main/.github/workflows/gh-aw-issue-triage.lock.yml)
 

--- a/docs/workflows/gh-aw-security-triage.md
+++ b/docs/workflows/gh-aw-security-triage.md
@@ -14,7 +14,7 @@ This reusable workflow triages newly opened security-related issues and prepares
 
 ## Usage
 
-The job `mint-gh-aw-github-token` mints an installation token via [`elastic/oblt-actions/github/create-token@v1`](https://github.com/elastic/oblt-actions/tree/v1/github/create-token). The job `security-issue-triage` calls:
+The job `mint-gh-aw-github-token` mints an installation token via [`elastic/oblt-actions/github/create-token@v1`](https://github.com/elastic/oblt-actions/tree/v1/github/create-token) with `skip-token-revoke: true` so the token is not revoked at mint job completion before the nested ai-github-actions workflow uses it (see [gh-aw-dependency-review.md](gh-aw-dependency-review.md) configuration). The job `security-issue-triage` calls:
 
 - [elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main](https://github.com/elastic/ai-github-actions/blob/main/.github/workflows/gh-aw-issue-triage.lock.yml)
 


### PR DESCRIPTION
## Summary

`elastic/ci-gh-actions/fetch-github-token` revokes the GitHub installation token in a post step when the mint job’s composite step finishes (when Vault issues a lease and `skip-token-revoke` is not set). The nested `elastic/ai-github-actions` job runs later and receives the same token string via `GH_AW_GITHUB_TOKEN`, but the credential is already invalid on GitHub. `safe_outputs` then falls back to `GITHUB_TOKEN`, so labels appear as `github-actions` and do not enqueue follow-on workflows.

## Changes

- Set `skip-token-revoke: 'true'` on `elastic/oblt-actions/github/create-token@v1` in:
  - `gh-aw-dependency-review.yml`
  - `gh-aw-security-triage.yml`
  - `gh-aw-resource-not-accessible-by-integration-triage.yml`
- Document the behavior in the matching workflow docs.

## Validation

- Pre-commit hooks (yamllint, actionlint, etc.) passed on commit.

Related issue: https://github.com/elastic/oblt-aw/issues/671
