### PR TITLE
fix(workflows): post-GH-AW label re-apply with ephemeral token (#4374)

### DIFF
--- a/.github/workflows/gh-aw-dependency-review.yml
+++ b/.github/workflows/gh-aw-dependency-review.yml
@@ -15,22 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  # Ephemeral installation token for GH-AW PR/label API calls so follow-on workflows are not suppressed
-  # (GITHUB_TOKEN mutations do not trigger other workflows).
-  mint-gh-aw-github-token:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    outputs:
-      token: ${{ steps.create-token.outputs.token }}
-    steps:
-      - name: Create ephemeral GitHub token
-        id: create-token
-        uses: elastic/oblt-actions/github/create-token@v1
-
   dependency-review:
-    needs: mint-gh-aw-github-token
     permissions:
       actions: read
       contents: read
@@ -70,4 +55,53 @@ jobs:
         - The comment's "Labels Applied" section must reflect labels you actually applied via add_labels, not merely recommended. If you applied a label, say so; if you did not apply any, say "No labels applied."
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-      GH_AW_GITHUB_TOKEN: ${{ needs.mint-gh-aw-github-token.outputs.token }}
+
+  # Workaround until we can mint ephemeral tokens inside agentic-workflows (elastic/observability-robots#4374):
+  # the nested workflow must not receive a cross-job token output. After it runs, mint here and
+  # remove+re-add `oblt-aw/ai/merge-ready` when present so ingress sees a `labeled` event from the
+  # installation token (GITHUB_TOKEN label writes do not trigger downstream workflows).
+  signal-dependency-review-followups:
+    needs: dependency-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Create ephemeral GitHub token
+        id: create-token
+        uses: elastic/oblt-actions/github/create-token@v1
+
+      - name: Re-apply merge-ready label to emit installation-token labeled event
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.create-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+            const names = issue.labels.map((l) => l.name);
+            const required = "oblt-aw/ai/merge-ready";
+            if (!names.includes(required)) {
+              core.info(`PR #${prNumber} missing ${required}; skipping re-apply.`);
+              return;
+            }
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: prNumber,
+              name: required,
+            });
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: [required],
+            });
+            core.info(`Re-applied ${required} on PR #${prNumber}.`);

--- a/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/gh-aw-resource-not-accessible-by-integration-triage.yml
@@ -10,28 +10,14 @@ on:
       COPILOT_GITHUB_TOKEN:
         required: true
 
-# Ephemeral installation token for GH-AW label/issue API so follow-on workflows are not suppressed
-# (GITHUB_TOKEN mutations do not trigger other workflows). Omit token-policy so Vault uses the
-# auto role token-policy-<12-char sha256(workflow ref base)> for this workflow file; register it in catalog-info.
+# Ephemeral token minting for label API runs only in signal-res-not-accessible-triage-followups (see #4374 workaround).
+# Omit token-policy on create-token so Vault uses the auto role token-policy-<12-char sha256(workflow ref base)>; register in catalog-info.
 permissions:
   actions: read
   contents: read
 
 jobs:
-  mint-gh-aw-github-token:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    outputs:
-      token: ${{ steps.create-token.outputs.token }}
-    steps:
-      - name: Create ephemeral GitHub token
-        id: create-token
-        uses: elastic/oblt-actions/github/create-token@v1
-
   res-not-accessible-integration-triage:
-    needs: mint-gh-aw-github-token
     permissions:
       actions: read
       contents: read
@@ -228,4 +214,53 @@ jobs:
         - [Troubleshooting Permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-      GH_AW_GITHUB_TOKEN: ${{ needs.mint-gh-aw-github-token.outputs.token }}
+
+  # Workaround until we can mint ephemeral tokens inside agentic-workflows (elastic/observability-robots#4374):
+  # mint only in this follow-up job; when the fixer preconditions hold, remove+re-add `oblt-aw/ai/fix-ready`
+  # so ingress sees a `labeled` event from the installation token.
+  signal-res-not-accessible-triage-followups:
+    needs: res-not-accessible-integration-triage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+    steps:
+      - name: Create ephemeral GitHub token
+        id: create-token
+        uses: elastic/oblt-actions/github/create-token@v1
+
+      - name: Re-apply fix-ready label to emit installation-token labeled event
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.create-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.issue.number;
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+            const names = issue.labels.map((l) => l.name);
+            const fixReady = "oblt-aw/ai/fix-ready";
+            const confirmed = "oblt-aw/triage/res-not-accessible-by-integration";
+            if (!names.includes(fixReady) || !names.includes(confirmed)) {
+              core.info(`Issue #${issueNumber} missing ${fixReady} or ${confirmed}; skipping re-apply.`);
+              return;
+            }
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              name: fixReady,
+            });
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              labels: [fixReady],
+            });
+            core.info(`Re-applied ${fixReady} on issue #${issueNumber}.`);

--- a/.github/workflows/gh-aw-security-triage.yml
+++ b/.github/workflows/gh-aw-security-triage.yml
@@ -10,27 +10,13 @@ on:
       COPILOT_GITHUB_TOKEN:
         required: true
 
-# Ephemeral installation token for GH-AW label/issue API so follow-on workflows are not suppressed
-# (GITHUB_TOKEN mutations do not trigger other workflows).
+# Ephemeral token minting for label API runs only in signal-security-triage-followups (see #4374 workaround).
 permissions:
   actions: read
   contents: read
 
 jobs:
-  mint-gh-aw-github-token:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    outputs:
-      token: ${{ steps.create-token.outputs.token }}
-    steps:
-      - name: Create ephemeral GitHub token
-        id: create-token
-        uses: elastic/oblt-actions/github/create-token@v1
-
   security-issue-triage:
-    needs: mint-gh-aw-github-token
     permissions:
       actions: read
       contents: read
@@ -117,4 +103,63 @@ jobs:
         - [Workflow Permission Syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-      GH_AW_GITHUB_TOKEN: ${{ needs.mint-gh-aw-github-token.outputs.token }}
+
+  # Workaround until we can mint ephemeral tokens inside agentic-workflows (elastic/observability-robots#4374):
+  # mint only in this follow-up job; remove+re-add `oblt-aw/ai/fix-ready` when the fixer preconditions
+  # hold so ingress sees a `labeled` event from the installation token.
+  signal-security-triage-followups:
+    needs: security-issue-triage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+    steps:
+      - name: Create ephemeral GitHub token
+        id: create-token
+        uses: elastic/oblt-actions/github/create-token@v1
+
+      - name: Re-apply fix-ready label to emit installation-token labeled event
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.create-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.issue.number;
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+            const names = issue.labels.map((l) => l.name);
+            const fixReady = "oblt-aw/ai/fix-ready";
+            const securityPrefixes = [
+              "oblt-aw/triage/security-injection",
+              "oblt-aw/triage/security-secrets",
+              "oblt-aw/triage/security-supply-chain",
+              "oblt-aw/triage/security-least-privilege",
+            ];
+            if (!names.includes(fixReady)) {
+              core.info(`Issue #${issueNumber} missing ${fixReady}; skipping re-apply.`);
+              return;
+            }
+            const hasSecurity = securityPrefixes.some((p) => names.includes(p));
+            if (!hasSecurity) {
+              core.info(`Issue #${issueNumber} missing a security triage label; skipping re-apply.`);
+              return;
+            }
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              name: fixReady,
+            });
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              labels: [fixReady],
+            });
+            core.info(`Re-applied ${fixReady} on issue #${issueNumber}.`);


### PR DESCRIPTION
## Summary
- Stop passing installation-token outputs into nested GH-AW reusable workflows; mint tokens only in follow-up jobs after the agentic job completes.
- Follow-up jobs verify expected labels, then remove and re-add `oblt-aw/ai/merge-ready` (dependency review) or `oblt-aw/ai/fix-ready` (security and resource-not-accessible triage) using the installation token so downstream workflows receive a normal `labeled` event instead of a suppressed `GITHUB_TOKEN` mutation.
- Ingress and the resource-not-accessible fixer workflow continue to gate on the existing `oblt-aw/ai/merge-ready` / `oblt-aw/ai/fix-ready` contracts.

## Validation
- Local pre-commit (yamllint, actionlint, YAML checks) passed on the committed workflow edits.

## Risks / Known Gaps
- Brief window where a label is removed before it is re-added; automation should tolerate the intermediate state.
- Docs under `docs/workflows/` may still describe the older mint-and-pass pattern until aligned in a follow-up.

Related issue: https://github.com/elastic/observability-robots/issues/4374
