### PR TITLE
fix(security): guard docs-pr-ai-menu against fork PRs (SEC-043)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo.
 *       @elastic/observablt-robots
+
+# Docs team owns the docs workflow templates.
+.github/remote-workflow-template/docs/  @elastic/observablt-robots @elastic/docs

--- a/.github/remote-workflow-template/docs/.github/workflows/docs-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/docs-ai-menu.yml
@@ -1,0 +1,678 @@
+name: Docs AI menu
+
+# Canonical home: elastic/oblt-aw/.github/remote-workflow-template/docs/.github/workflows/docs-ai-menu.yml
+# Distributed automatically to repos listed in elastic/oblt-aw/config/docs/active-repositories.json.
+# Helper logic is inlined inside each actions/github-script step so the file is self-contained
+# (no .github/scripts/ dependency in target repos).
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [edited]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to post or refresh the AI menu on.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  post-menu:
+    name: Post or refresh AI menu
+    if: github.event_name == 'issues' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number || github.event.inputs.issue_number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Create or update AI menu comment
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ─── Inlined helpers (canonical: docs_ai_menu.cjs) ───
+            const MENU_START = '<!-- docs-ai-menu:start -->';
+            const MENU_END = '<!-- docs-ai-menu:end -->';
+            const WORKFLOW_CONFIG = {
+              triage: {
+                label: 'Triage ([`docs-triage`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-issue-triage.md)).',
+                marker: '<!-- docs-ai-menu:triage -->',
+              },
+              issueScope: {
+                label: 'Scope the docs work ([`docs-issue-scope`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-issue-scope.md)).',
+                marker: '<!-- docs-ai-menu:issue-scope -->',
+              },
+            };
+            const WORKFLOW_ORDER = ['triage', 'issueScope'];
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+            function getLinePattern(key) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              return new RegExp(
+                `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
+                'm'
+              );
+            }
+            function isMenuComment(body) {
+              return (body || '').includes(MENU_START) && (body || '').includes(MENU_END);
+            }
+            function parseWorkflowState(body, key) {
+              const match = (body || '').match(getLinePattern(key));
+              if (!match) return { selected: false };
+              return { selected: match[1] === 'x', statusText: match[2] || null };
+            }
+            function parseMenuState(body) {
+              const state = {};
+              for (const key of WORKFLOW_ORDER) state[key] = parseWorkflowState(body, key);
+              return state;
+            }
+            function getStatusText(workflowState, workflowStatus) {
+              if (workflowStatus?.statusText) return workflowStatus.statusText;
+              const progressLink = workflowStatus?.detailsUrl ? ` [View progress](${workflowStatus.detailsUrl}).` : '';
+              if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') return `Status: running.${progressLink}`;
+              if (workflowStatus?.status === 'completed') {
+                if (workflowStatus.conclusion === 'success') return `Status: completed.${progressLink}`;
+                if (workflowStatus.conclusion === 'cancelled') return `Status: cancelled.${progressLink}`;
+                return `Status: needs attention.${progressLink}`;
+              }
+              if (workflowState?.statusText) return workflowState.statusText;
+              if (workflowState?.selected) return 'Status: queued.';
+              return 'Status: not started.';
+            }
+            function buildWorkflowLine(key, workflowState, workflowStatus) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              const selected = workflowState?.selected ? 'x' : ' ';
+              const statusText = getStatusText(workflowState, workflowStatus);
+              return `- [${selected}] ${label} ${statusText} ${marker}`;
+            }
+            function buildMenuBody(state, statuses) {
+              const normalizedState = state || {};
+              const normalizedStatuses = statuses || {};
+              return [
+                MENU_START,
+                '## Elastic Docs AI Menu',
+                '',
+                'Check one box to run an AI workflow for this issue.',
+                '',
+                ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key], normalizedStatuses[key])),
+                '',
+                'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
+                '',
+                MENU_END,
+              ].join('\n');
+            }
+            async function findMenuComment(github, context, issueNumber) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, per_page: 100,
+              });
+              return comments.find((c) => c.user?.login === 'github-actions[bot]' && isMenuComment(c.body));
+            }
+            function buildWorkflowStatuses(existingState, statusOverrides) {
+              return Object.fromEntries(
+                WORKFLOW_ORDER.map((key) => [key, statusOverrides?.[key] || { statusText: existingState?.[key]?.statusText }])
+              );
+            }
+            async function upsertMenuComment({ core, createIfMissing = true, github, context, issueNumber, statusOverrides }) {
+              const existingComment = await findMenuComment(github, context, issueNumber);
+              if (!existingComment && !createIfMissing) {
+                core?.warning('AI menu comment was not found.');
+                return;
+              }
+              const existingState = parseMenuState(existingComment?.body || '');
+              const statuses = buildWorkflowStatuses(existingState, statusOverrides);
+              const body = buildMenuBody(existingState, statuses);
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existingComment.id, body,
+                });
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, body,
+              });
+            }
+            // ─── End helpers ───
+
+            const workflowDispatchIssueNumber = context.payload.inputs?.issue_number;
+            const issueNumber = context.eventName === 'workflow_dispatch'
+              ? Number(workflowDispatchIssueNumber)
+              : context.payload.issue.number;
+
+            if (!issueNumber) {
+              core.setFailed('Issue number is required for workflow_dispatch runs.');
+              return;
+            }
+
+            await upsertMenuComment({ core, github, context, issueNumber });
+
+  evaluate-trigger:
+    name: Evaluate AI menu trigger
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
+      github.actor != 'github-actions[bot]' &&
+      github.event.comment.user.login == 'github-actions[bot]' &&
+      contains(github.event.comment.body, '<!-- docs-ai-menu:start -->') &&
+      contains(github.event.comment.body, '<!-- docs-ai-menu:end -->')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      triage_triggered: ${{ steps.evaluate.outputs.triage_triggered }}
+      issue_scope_triggered: ${{ steps.evaluate.outputs.issue_scope_triggered }}
+
+    steps:
+      - name: Parse AI menu transition
+        id: evaluate
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ─── Inlined helpers (parseMenuState only) ───
+            const WORKFLOW_CONFIG = {
+              triage: {
+                label: 'Triage ([`docs-triage`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-issue-triage.md)).',
+                marker: '<!-- docs-ai-menu:triage -->',
+              },
+              issueScope: {
+                label: 'Scope the docs work ([`docs-issue-scope`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-issue-scope.md)).',
+                marker: '<!-- docs-ai-menu:issue-scope -->',
+              },
+            };
+            const WORKFLOW_ORDER = ['triage', 'issueScope'];
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+            function getLinePattern(key) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              return new RegExp(
+                `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
+                'm'
+              );
+            }
+            function parseWorkflowState(body, key) {
+              const match = (body || '').match(getLinePattern(key));
+              if (!match) return { selected: false };
+              return { selected: match[1] === 'x', statusText: match[2] || null };
+            }
+            function parseMenuState(body) {
+              const state = {};
+              for (const key of WORKFLOW_ORDER) state[key] = parseWorkflowState(body, key);
+              return state;
+            }
+            // ─── End helpers ───
+
+            const body = context.payload.comment.body || '';
+            const previousBody = context.payload.changes?.body?.from || '';
+
+            const previousState = parseMenuState(previousBody);
+            const currentState = parseMenuState(body);
+            const triageTriggered = !previousState.triage.selected && currentState.triage.selected;
+            const issueScopeTriggered = !previousState.issueScope.selected && currentState.issueScope.selected;
+
+            core.setOutput('triage_triggered', String(triageTriggered));
+            core.setOutput('issue_scope_triggered', String(issueScopeTriggered));
+
+  refresh-menu-after-trigger:
+    name: Refresh AI menu after trigger
+    needs: [evaluate-trigger]
+    if: >-
+      needs.evaluate-trigger.outputs.triage_triggered == 'true' ||
+      needs.evaluate-trigger.outputs.issue_scope_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Refresh AI menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ─── Inlined helpers (canonical: docs_ai_menu.cjs) ───
+            const MENU_START = '<!-- docs-ai-menu:start -->';
+            const MENU_END = '<!-- docs-ai-menu:end -->';
+            const WORKFLOW_CONFIG = {
+              triage: {
+                label: 'Triage ([`docs-triage`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-issue-triage.md)).',
+                marker: '<!-- docs-ai-menu:triage -->',
+              },
+              issueScope: {
+                label: 'Scope the docs work ([`docs-issue-scope`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-issue-scope.md)).',
+                marker: '<!-- docs-ai-menu:issue-scope -->',
+              },
+            };
+            const WORKFLOW_ORDER = ['triage', 'issueScope'];
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+            function getLinePattern(key) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              return new RegExp(
+                `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
+                'm'
+              );
+            }
+            function isMenuComment(body) {
+              return (body || '').includes(MENU_START) && (body || '').includes(MENU_END);
+            }
+            function parseWorkflowState(body, key) {
+              const match = (body || '').match(getLinePattern(key));
+              if (!match) return { selected: false };
+              return { selected: match[1] === 'x', statusText: match[2] || null };
+            }
+            function parseMenuState(body) {
+              const state = {};
+              for (const key of WORKFLOW_ORDER) state[key] = parseWorkflowState(body, key);
+              return state;
+            }
+            function getStatusText(workflowState, workflowStatus) {
+              if (workflowStatus?.statusText) return workflowStatus.statusText;
+              const progressLink = workflowStatus?.detailsUrl ? ` [View progress](${workflowStatus.detailsUrl}).` : '';
+              if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') return `Status: running.${progressLink}`;
+              if (workflowStatus?.status === 'completed') {
+                if (workflowStatus.conclusion === 'success') return `Status: completed.${progressLink}`;
+                if (workflowStatus.conclusion === 'cancelled') return `Status: cancelled.${progressLink}`;
+                return `Status: needs attention.${progressLink}`;
+              }
+              if (workflowState?.statusText) return workflowState.statusText;
+              if (workflowState?.selected) return 'Status: queued.';
+              return 'Status: not started.';
+            }
+            function buildWorkflowLine(key, workflowState, workflowStatus) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              const selected = workflowState?.selected ? 'x' : ' ';
+              const statusText = getStatusText(workflowState, workflowStatus);
+              return `- [${selected}] ${label} ${statusText} ${marker}`;
+            }
+            function buildMenuBody(state, statuses) {
+              const normalizedState = state || {};
+              const normalizedStatuses = statuses || {};
+              return [
+                MENU_START,
+                '## Elastic Docs AI Menu',
+                '',
+                'Check one box to run an AI workflow for this issue.',
+                '',
+                ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key], normalizedStatuses[key])),
+                '',
+                'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
+                '',
+                MENU_END,
+              ].join('\n');
+            }
+            async function findMenuComment(github, context, issueNumber) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, per_page: 100,
+              });
+              return comments.find((c) => c.user?.login === 'github-actions[bot]' && isMenuComment(c.body));
+            }
+            function buildWorkflowStatuses(existingState, statusOverrides) {
+              return Object.fromEntries(
+                WORKFLOW_ORDER.map((key) => [key, statusOverrides?.[key] || { statusText: existingState?.[key]?.statusText }])
+              );
+            }
+            async function upsertMenuComment({ core, createIfMissing = true, github, context, issueNumber, statusOverrides }) {
+              const existingComment = await findMenuComment(github, context, issueNumber);
+              if (!existingComment && !createIfMissing) {
+                core?.warning('AI menu comment was not found.');
+                return;
+              }
+              const existingState = parseMenuState(existingComment?.body || '');
+              const statuses = buildWorkflowStatuses(existingState, statusOverrides);
+              const body = buildMenuBody(existingState, statuses);
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existingComment.id, body,
+                });
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, body,
+              });
+            }
+            // ─── End helpers ───
+
+            const issueNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const statusOverrides = {};
+
+            if ('${{ needs.evaluate-trigger.outputs.triage_triggered }}' === 'true') {
+              statusOverrides.triage = { detailsUrl: progressUrl, status: 'in_progress' };
+            }
+
+            if ('${{ needs.evaluate-trigger.outputs.issue_scope_triggered }}' === 'true') {
+              statusOverrides.issueScope = { detailsUrl: progressUrl, status: 'in_progress' };
+            }
+
+            await upsertMenuComment({
+              core, createIfMissing: false, github, context, issueNumber, statusOverrides,
+            });
+
+  run-docs-triage:
+    name: Docs AI / triage
+    needs: [evaluate-trigger]
+    if: needs.evaluate-trigger.outputs.triage_triggered == 'true'
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
+    uses: elastic/docs-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v1
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  run-docs-issue-scope:
+    name: Docs AI / issue scope
+    needs: [evaluate-trigger]
+    if: needs.evaluate-trigger.outputs.issue_scope_triggered == 'true'
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-issue-scope.lock.yml@v1
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  refresh-menu-after-docs-triage:
+    name: Refresh AI menu after docs triage
+    needs: [evaluate-trigger, refresh-menu-after-trigger, run-docs-triage]
+    if: always() && needs.evaluate-trigger.outputs.triage_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Refresh AI menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ─── Inlined helpers (canonical: docs_ai_menu.cjs) ───
+            const MENU_START = '<!-- docs-ai-menu:start -->';
+            const MENU_END = '<!-- docs-ai-menu:end -->';
+            const WORKFLOW_CONFIG = {
+              triage: {
+                label: 'Triage ([`docs-triage`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-issue-triage.md)).',
+                marker: '<!-- docs-ai-menu:triage -->',
+              },
+              issueScope: {
+                label: 'Scope the docs work ([`docs-issue-scope`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-issue-scope.md)).',
+                marker: '<!-- docs-ai-menu:issue-scope -->',
+              },
+            };
+            const WORKFLOW_ORDER = ['triage', 'issueScope'];
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+            function getLinePattern(key) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              return new RegExp(
+                `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
+                'm'
+              );
+            }
+            function isMenuComment(body) {
+              return (body || '').includes(MENU_START) && (body || '').includes(MENU_END);
+            }
+            function parseWorkflowState(body, key) {
+              const match = (body || '').match(getLinePattern(key));
+              if (!match) return { selected: false };
+              return { selected: match[1] === 'x', statusText: match[2] || null };
+            }
+            function parseMenuState(body) {
+              const state = {};
+              for (const key of WORKFLOW_ORDER) state[key] = parseWorkflowState(body, key);
+              return state;
+            }
+            function getStatusText(workflowState, workflowStatus) {
+              if (workflowStatus?.statusText) return workflowStatus.statusText;
+              const progressLink = workflowStatus?.detailsUrl ? ` [View progress](${workflowStatus.detailsUrl}).` : '';
+              if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') return `Status: running.${progressLink}`;
+              if (workflowStatus?.status === 'completed') {
+                if (workflowStatus.conclusion === 'success') return `Status: completed.${progressLink}`;
+                if (workflowStatus.conclusion === 'cancelled') return `Status: cancelled.${progressLink}`;
+                return `Status: needs attention.${progressLink}`;
+              }
+              if (workflowState?.statusText) return workflowState.statusText;
+              if (workflowState?.selected) return 'Status: queued.';
+              return 'Status: not started.';
+            }
+            function buildWorkflowLine(key, workflowState, workflowStatus) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              const selected = workflowState?.selected ? 'x' : ' ';
+              const statusText = getStatusText(workflowState, workflowStatus);
+              return `- [${selected}] ${label} ${statusText} ${marker}`;
+            }
+            function buildMenuBody(state, statuses) {
+              const normalizedState = state || {};
+              const normalizedStatuses = statuses || {};
+              return [
+                MENU_START,
+                '## Elastic Docs AI Menu',
+                '',
+                'Check one box to run an AI workflow for this issue.',
+                '',
+                ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key], normalizedStatuses[key])),
+                '',
+                'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
+                '',
+                MENU_END,
+              ].join('\n');
+            }
+            async function findMenuComment(github, context, issueNumber) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, per_page: 100,
+              });
+              return comments.find((c) => c.user?.login === 'github-actions[bot]' && isMenuComment(c.body));
+            }
+            function buildWorkflowStatuses(existingState, statusOverrides) {
+              return Object.fromEntries(
+                WORKFLOW_ORDER.map((key) => [key, statusOverrides?.[key] || { statusText: existingState?.[key]?.statusText }])
+              );
+            }
+            async function upsertMenuComment({ core, createIfMissing = true, github, context, issueNumber, statusOverrides }) {
+              const existingComment = await findMenuComment(github, context, issueNumber);
+              if (!existingComment && !createIfMissing) {
+                core?.warning('AI menu comment was not found.');
+                return;
+              }
+              const existingState = parseMenuState(existingComment?.body || '');
+              const statuses = buildWorkflowStatuses(existingState, statusOverrides);
+              const body = buildMenuBody(existingState, statuses);
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existingComment.id, body,
+                });
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, body,
+              });
+            }
+            // ─── End helpers ───
+
+            const issueNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const triageResult = '${{ needs.run-docs-triage.result }}';
+
+            await upsertMenuComment({
+              core, createIfMissing: false, github, context, issueNumber,
+              statusOverrides: {
+                triage: {
+                  conclusion: triageResult === 'success' ? 'success' : triageResult === 'cancelled' ? 'cancelled' : 'failure',
+                  detailsUrl: progressUrl,
+                  status: 'completed',
+                },
+              },
+            });
+
+  refresh-menu-after-docs-issue-scope:
+    name: Refresh AI menu after docs issue scope
+    needs: [evaluate-trigger, refresh-menu-after-trigger, run-docs-issue-scope]
+    if: always() && needs.evaluate-trigger.outputs.issue_scope_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Refresh AI menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ─── Inlined helpers (canonical: docs_ai_menu.cjs) ───
+            const MENU_START = '<!-- docs-ai-menu:start -->';
+            const MENU_END = '<!-- docs-ai-menu:end -->';
+            const WORKFLOW_CONFIG = {
+              triage: {
+                label: 'Triage ([`docs-triage`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-issue-triage.md)).',
+                marker: '<!-- docs-ai-menu:triage -->',
+              },
+              issueScope: {
+                label: 'Scope the docs work ([`docs-issue-scope`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-issue-scope.md)).',
+                marker: '<!-- docs-ai-menu:issue-scope -->',
+              },
+            };
+            const WORKFLOW_ORDER = ['triage', 'issueScope'];
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+            function getLinePattern(key) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              return new RegExp(
+                `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
+                'm'
+              );
+            }
+            function isMenuComment(body) {
+              return (body || '').includes(MENU_START) && (body || '').includes(MENU_END);
+            }
+            function parseWorkflowState(body, key) {
+              const match = (body || '').match(getLinePattern(key));
+              if (!match) return { selected: false };
+              return { selected: match[1] === 'x', statusText: match[2] || null };
+            }
+            function parseMenuState(body) {
+              const state = {};
+              for (const key of WORKFLOW_ORDER) state[key] = parseWorkflowState(body, key);
+              return state;
+            }
+            function getStatusText(workflowState, workflowStatus) {
+              if (workflowStatus?.statusText) return workflowStatus.statusText;
+              const progressLink = workflowStatus?.detailsUrl ? ` [View progress](${workflowStatus.detailsUrl}).` : '';
+              if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') return `Status: running.${progressLink}`;
+              if (workflowStatus?.status === 'completed') {
+                if (workflowStatus.conclusion === 'success') return `Status: completed.${progressLink}`;
+                if (workflowStatus.conclusion === 'cancelled') return `Status: cancelled.${progressLink}`;
+                return `Status: needs attention.${progressLink}`;
+              }
+              if (workflowState?.statusText) return workflowState.statusText;
+              if (workflowState?.selected) return 'Status: queued.';
+              return 'Status: not started.';
+            }
+            function buildWorkflowLine(key, workflowState, workflowStatus) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              const selected = workflowState?.selected ? 'x' : ' ';
+              const statusText = getStatusText(workflowState, workflowStatus);
+              return `- [${selected}] ${label} ${statusText} ${marker}`;
+            }
+            function buildMenuBody(state, statuses) {
+              const normalizedState = state || {};
+              const normalizedStatuses = statuses || {};
+              return [
+                MENU_START,
+                '## Elastic Docs AI Menu',
+                '',
+                'Check one box to run an AI workflow for this issue.',
+                '',
+                ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key], normalizedStatuses[key])),
+                '',
+                'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
+                '',
+                MENU_END,
+              ].join('\n');
+            }
+            async function findMenuComment(github, context, issueNumber) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, per_page: 100,
+              });
+              return comments.find((c) => c.user?.login === 'github-actions[bot]' && isMenuComment(c.body));
+            }
+            function buildWorkflowStatuses(existingState, statusOverrides) {
+              return Object.fromEntries(
+                WORKFLOW_ORDER.map((key) => [key, statusOverrides?.[key] || { statusText: existingState?.[key]?.statusText }])
+              );
+            }
+            async function upsertMenuComment({ core, createIfMissing = true, github, context, issueNumber, statusOverrides }) {
+              const existingComment = await findMenuComment(github, context, issueNumber);
+              if (!existingComment && !createIfMissing) {
+                core?.warning('AI menu comment was not found.');
+                return;
+              }
+              const existingState = parseMenuState(existingComment?.body || '');
+              const statuses = buildWorkflowStatuses(existingState, statusOverrides);
+              const body = buildMenuBody(existingState, statuses);
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existingComment.id, body,
+                });
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, body,
+              });
+            }
+            // ─── End helpers ───
+
+            const issueNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const issueScopeResult = '${{ needs.run-docs-issue-scope.result }}';
+
+            await upsertMenuComment({
+              core, createIfMissing: false, github, context, issueNumber,
+              statusOverrides: {
+                issueScope: {
+                  conclusion: issueScopeResult === 'success' ? 'success' : issueScopeResult === 'cancelled' ? 'cancelled' : 'failure',
+                  detailsUrl: progressUrl,
+                  status: 'completed',
+                },
+              },
+            });

--- a/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu-collect.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu-collect.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "$PR_NUMBER" > pr_number.txt
 
       - name: Upload PR number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-number
           path: pr_number.txt

--- a/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu-collect.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu-collect.yml
@@ -1,0 +1,33 @@
+name: Docs PR AI menu (collect)
+
+# Canonical home: elastic/oblt-aw/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu-collect.yml
+# Distributed automatically to repos listed in elastic/oblt-aw/config/docs/active-repositories.json.
+# Part of the split-workflow pattern: saves the PR number as an artifact so that
+# docs-pr-ai-menu.yml can post the AI PR menu comment from a trusted workflow_run context,
+# avoiding the need for pull_request_target.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  collect:
+    name: Save PR number
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr_number.txt
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
@@ -1,0 +1,625 @@
+name: Docs PR AI menu
+
+# Canonical home: elastic/oblt-aw/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
+# Distributed automatically to repos listed in elastic/oblt-aw/config/docs/active-repositories.json.
+# Helper logic is inlined inside each actions/github-script step so the file is self-contained
+# (no .github/scripts/ dependency in target repos).
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [edited]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to post or refresh the AI PR menu on.
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  post-menu:
+    name: Post or refresh AI PR menu
+    if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: docs-pr-ai-menu-${{ github.event.pull_request.number || github.event.inputs.pull_request_number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Create or update AI PR menu comment
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ─── Inlined helpers (canonical: docs_pr_ai_menu.cjs) ───
+            const MENU_START = '<!-- docs-pr-ai-menu:start -->';
+            const MENU_END = '<!-- docs-pr-ai-menu:end -->';
+            const WORKFLOW_CONFIG = {
+              docsReview: {
+                checkNamePrefix: 'Docs AI / docs review',
+                label: 'Review docs changes ([`docs-review`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-review.md)).',
+                marker: '<!-- docs-pr-ai-menu:docs-review -->',
+              },
+            };
+            const WORKFLOW_ORDER = ['docsReview'];
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+            function getLinePattern(key) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              return new RegExp(
+                `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
+                'm'
+              );
+            }
+            function parseWorkflowState(body, key) {
+              const match = (body || '').match(getLinePattern(key));
+              if (!match) return { selected: false };
+              return { selected: match[1] === 'x', statusText: match[2] || null };
+            }
+            function parseMenuState(body) {
+              const state = {};
+              for (const key of WORKFLOW_ORDER) state[key] = parseWorkflowState(body, key);
+              return state;
+            }
+            function getStatusText(workflowState, workflowStatus) {
+              if (workflowStatus?.statusText) return workflowStatus.statusText;
+              const progressLink = workflowStatus?.detailsUrl ? ` [View progress](${workflowStatus.detailsUrl}).` : '';
+              if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') return `Status: running.${progressLink}`;
+              if (workflowStatus?.status === 'completed') {
+                if (workflowStatus.conclusion === 'success') return `Status: completed.${progressLink}`;
+                if (workflowStatus.conclusion === 'cancelled') return `Status: cancelled.${progressLink}`;
+                return `Status: needs attention.${progressLink}`;
+              }
+              if (workflowState?.selected) return 'Status: queued.';
+              return 'Status: not started.';
+            }
+            function getWorkflowStatusFromCheckRuns(key, checkRuns) {
+              const { checkNamePrefix } = WORKFLOW_CONFIG[key];
+              const matchingCheckRuns = (checkRuns || []).filter((cr) =>
+                cr.name?.startsWith(checkNamePrefix) && cr.conclusion !== 'skipped'
+              );
+              if (matchingCheckRuns.length === 0) return null;
+              matchingCheckRuns.sort((l, r) =>
+                new Date(r.started_at || r.created_at || 0) - new Date(l.started_at || l.created_at || 0)
+              );
+              return {
+                conclusion: matchingCheckRuns[0].conclusion,
+                detailsUrl: matchingCheckRuns[0].details_url,
+                status: matchingCheckRuns[0].status,
+              };
+            }
+            function buildWorkflowLine(key, workflowState, workflowStatus) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              const selected = workflowState?.selected ? 'x' : ' ';
+              const statusText = getStatusText(workflowState, workflowStatus);
+              return `- [${selected}] ${label} ${statusText} ${marker}`;
+            }
+            function buildMenuBody(state, statuses) {
+              const normalizedState = state || {};
+              const normalizedStatuses = statuses || {};
+              return [
+                MENU_START,
+                '## Elastic Docs AI PR menu',
+                '',
+                'Check the box to run an AI review for this pull request.',
+                '',
+                ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key], normalizedStatuses[key])),
+                '',
+                'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
+                '',
+                MENU_END,
+              ].join('\n');
+            }
+            async function getCheckRunsForPullRequest(github, context, pullRequestNumber) {
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner, repo: context.repo.repo, pull_number: pullRequestNumber,
+              });
+              const { data: checks } = await github.rest.checks.listForRef({
+                owner: context.repo.owner, repo: context.repo.repo,
+                ref: pullRequest.head.sha, per_page: 100,
+              });
+              return checks.check_runs || [];
+            }
+            async function findMenuComment(github, context, pullRequestNumber) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pullRequestNumber, per_page: 100,
+              });
+              return comments.find((c) =>
+                c.user?.login === 'github-actions[bot]' &&
+                c.body?.includes(MENU_START) && c.body?.includes(MENU_END)
+              );
+            }
+            function getActiveWorkflowStatusFromState(workflowState) {
+              if (workflowState?.statusText?.startsWith('Status: running.')) {
+                return { statusText: workflowState.statusText };
+              }
+              return null;
+            }
+            function buildWorkflowStatuses(checkRuns, statusOverrides, existingState) {
+              return Object.fromEntries(
+                WORKFLOW_ORDER.map((key) => [
+                  key,
+                  statusOverrides?.[key] ||
+                    getWorkflowStatusFromCheckRuns(key, checkRuns) ||
+                    getActiveWorkflowStatusFromState(existingState?.[key]),
+                ])
+              );
+            }
+            async function upsertMenuComment({ core, createIfMissing = true, github, context, pullRequestNumber, statusOverrides }) {
+              const checkRuns = await getCheckRunsForPullRequest(github, context, pullRequestNumber);
+              const existingComment = await findMenuComment(github, context, pullRequestNumber);
+              if (!existingComment && !createIfMissing) {
+                core?.warning('AI PR menu comment was not found.');
+                return;
+              }
+              const existingState = parseMenuState(existingComment?.body || '');
+              const statuses = buildWorkflowStatuses(checkRuns, statusOverrides, existingState);
+              const body = buildMenuBody(existingState, statuses);
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existingComment.id, body,
+                });
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pullRequestNumber, body,
+              });
+            }
+            // ─── End helpers ───
+
+            const workflowDispatchPrNumber = context.payload.inputs?.pull_request_number;
+            const pullRequestNumber = context.eventName === 'workflow_dispatch'
+              ? Number(workflowDispatchPrNumber)
+              : context.payload.pull_request.number;
+
+            if (!pullRequestNumber) {
+              core.setFailed('Pull request number is required for workflow_dispatch runs.');
+              return;
+            }
+
+            await upsertMenuComment({ core, github, context, pullRequestNumber });
+
+  evaluate-trigger:
+    name: Evaluate AI PR menu trigger
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      github.actor != 'github-actions[bot]' &&
+      github.event.comment.user.login == 'github-actions[bot]' &&
+      contains(github.event.comment.body, '<!-- docs-pr-ai-menu:start -->') &&
+      contains(github.event.comment.body, '<!-- docs-pr-ai-menu:end -->')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      docs_review_triggered: ${{ steps.evaluate.outputs.docs_review_triggered }}
+
+    steps:
+      - name: Parse AI PR menu transition
+        id: evaluate
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ─── Inlined helpers (parseMenuState only) ───
+            const WORKFLOW_CONFIG = {
+              docsReview: {
+                checkNamePrefix: 'Docs AI / docs review',
+                label: 'Review docs changes ([`docs-review`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-review.md)).',
+                marker: '<!-- docs-pr-ai-menu:docs-review -->',
+              },
+            };
+            const WORKFLOW_ORDER = ['docsReview'];
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+            function getLinePattern(key) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              return new RegExp(
+                `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
+                'm'
+              );
+            }
+            function parseWorkflowState(body, key) {
+              const match = (body || '').match(getLinePattern(key));
+              if (!match) return { selected: false };
+              return { selected: match[1] === 'x', statusText: match[2] || null };
+            }
+            function parseMenuState(body) {
+              const state = {};
+              for (const key of WORKFLOW_ORDER) state[key] = parseWorkflowState(body, key);
+              return state;
+            }
+            // ─── End helpers ───
+
+            const body = context.payload.comment.body || '';
+            const previousBody = context.payload.changes?.body?.from || '';
+
+            const previousState = parseMenuState(previousBody);
+            const currentState = parseMenuState(body);
+            const docsReviewTriggered =
+              !previousState.docsReview.selected && currentState.docsReview.selected;
+
+            core.setOutput('docs_review_triggered', String(docsReviewTriggered));
+
+  refresh-menu-after-trigger:
+    name: Refresh AI PR menu after trigger
+    needs: [evaluate-trigger]
+    if: needs.evaluate-trigger.outputs.docs_review_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: docs-pr-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Refresh AI PR menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ─── Inlined helpers (canonical: docs_pr_ai_menu.cjs) ───
+            const MENU_START = '<!-- docs-pr-ai-menu:start -->';
+            const MENU_END = '<!-- docs-pr-ai-menu:end -->';
+            const WORKFLOW_CONFIG = {
+              docsReview: {
+                checkNamePrefix: 'Docs AI / docs review',
+                label: 'Review docs changes ([`docs-review`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-review.md)).',
+                marker: '<!-- docs-pr-ai-menu:docs-review -->',
+              },
+            };
+            const WORKFLOW_ORDER = ['docsReview'];
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+            function getLinePattern(key) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              return new RegExp(
+                `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
+                'm'
+              );
+            }
+            function parseWorkflowState(body, key) {
+              const match = (body || '').match(getLinePattern(key));
+              if (!match) return { selected: false };
+              return { selected: match[1] === 'x', statusText: match[2] || null };
+            }
+            function parseMenuState(body) {
+              const state = {};
+              for (const key of WORKFLOW_ORDER) state[key] = parseWorkflowState(body, key);
+              return state;
+            }
+            function getStatusText(workflowState, workflowStatus) {
+              if (workflowStatus?.statusText) return workflowStatus.statusText;
+              const progressLink = workflowStatus?.detailsUrl ? ` [View progress](${workflowStatus.detailsUrl}).` : '';
+              if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') return `Status: running.${progressLink}`;
+              if (workflowStatus?.status === 'completed') {
+                if (workflowStatus.conclusion === 'success') return `Status: completed.${progressLink}`;
+                if (workflowStatus.conclusion === 'cancelled') return `Status: cancelled.${progressLink}`;
+                return `Status: needs attention.${progressLink}`;
+              }
+              if (workflowState?.selected) return 'Status: queued.';
+              return 'Status: not started.';
+            }
+            function getWorkflowStatusFromCheckRuns(key, checkRuns) {
+              const { checkNamePrefix } = WORKFLOW_CONFIG[key];
+              const matchingCheckRuns = (checkRuns || []).filter((cr) =>
+                cr.name?.startsWith(checkNamePrefix) && cr.conclusion !== 'skipped'
+              );
+              if (matchingCheckRuns.length === 0) return null;
+              matchingCheckRuns.sort((l, r) =>
+                new Date(r.started_at || r.created_at || 0) - new Date(l.started_at || l.created_at || 0)
+              );
+              return {
+                conclusion: matchingCheckRuns[0].conclusion,
+                detailsUrl: matchingCheckRuns[0].details_url,
+                status: matchingCheckRuns[0].status,
+              };
+            }
+            function buildWorkflowLine(key, workflowState, workflowStatus) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              const selected = workflowState?.selected ? 'x' : ' ';
+              const statusText = getStatusText(workflowState, workflowStatus);
+              return `- [${selected}] ${label} ${statusText} ${marker}`;
+            }
+            function buildMenuBody(state, statuses) {
+              const normalizedState = state || {};
+              const normalizedStatuses = statuses || {};
+              return [
+                MENU_START,
+                '## Elastic Docs AI PR menu',
+                '',
+                'Check the box to run an AI review for this pull request.',
+                '',
+                ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key], normalizedStatuses[key])),
+                '',
+                'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
+                '',
+                MENU_END,
+              ].join('\n');
+            }
+            async function getCheckRunsForPullRequest(github, context, pullRequestNumber) {
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner, repo: context.repo.repo, pull_number: pullRequestNumber,
+              });
+              const { data: checks } = await github.rest.checks.listForRef({
+                owner: context.repo.owner, repo: context.repo.repo,
+                ref: pullRequest.head.sha, per_page: 100,
+              });
+              return checks.check_runs || [];
+            }
+            async function findMenuComment(github, context, pullRequestNumber) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pullRequestNumber, per_page: 100,
+              });
+              return comments.find((c) =>
+                c.user?.login === 'github-actions[bot]' &&
+                c.body?.includes(MENU_START) && c.body?.includes(MENU_END)
+              );
+            }
+            function getActiveWorkflowStatusFromState(workflowState) {
+              if (workflowState?.statusText?.startsWith('Status: running.')) {
+                return { statusText: workflowState.statusText };
+              }
+              return null;
+            }
+            function buildWorkflowStatuses(checkRuns, statusOverrides, existingState) {
+              return Object.fromEntries(
+                WORKFLOW_ORDER.map((key) => [
+                  key,
+                  statusOverrides?.[key] ||
+                    getWorkflowStatusFromCheckRuns(key, checkRuns) ||
+                    getActiveWorkflowStatusFromState(existingState?.[key]),
+                ])
+              );
+            }
+            async function upsertMenuComment({ core, createIfMissing = true, github, context, pullRequestNumber, statusOverrides }) {
+              const checkRuns = await getCheckRunsForPullRequest(github, context, pullRequestNumber);
+              const existingComment = await findMenuComment(github, context, pullRequestNumber);
+              if (!existingComment && !createIfMissing) {
+                core?.warning('AI PR menu comment was not found.');
+                return;
+              }
+              const existingState = parseMenuState(existingComment?.body || '');
+              const statuses = buildWorkflowStatuses(checkRuns, statusOverrides, existingState);
+              const body = buildMenuBody(existingState, statuses);
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existingComment.id, body,
+                });
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pullRequestNumber, body,
+              });
+            }
+            // ─── End helpers ───
+
+            const pullRequestNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            await upsertMenuComment({
+              core, createIfMissing: false, github, context, pullRequestNumber,
+              statusOverrides: {
+                docsReview: { detailsUrl: progressUrl, status: 'in_progress' },
+              },
+            });
+
+  run-docs-review:
+    name: Docs AI / docs review
+    needs: [evaluate-trigger]
+    if: needs.evaluate-trigger.outputs.docs_review_triggered == 'true'
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-review.lock.yml@v1
+    with:
+      review-scope: repo-wide-markdown
+      additional-instructions: |
+        This repository stores documentation as markdown across the repository.
+        Prefer concise, high-signal review comments with exact replacement text when possible.
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  refresh-menu-after-docs-review:
+    name: Refresh AI PR menu after docs review
+    needs: [evaluate-trigger, run-docs-review]
+    if: always() && needs.evaluate-trigger.outputs.docs_review_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: docs-pr-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Refresh AI PR menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ─── Inlined helpers (canonical: docs_pr_ai_menu.cjs) ───
+            const MENU_START = '<!-- docs-pr-ai-menu:start -->';
+            const MENU_END = '<!-- docs-pr-ai-menu:end -->';
+            const WORKFLOW_CONFIG = {
+              docsReview: {
+                checkNamePrefix: 'Docs AI / docs review',
+                label: 'Review docs changes ([`docs-review`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-review.md)).',
+                marker: '<!-- docs-pr-ai-menu:docs-review -->',
+              },
+            };
+            const WORKFLOW_ORDER = ['docsReview'];
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+            function getLinePattern(key) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              return new RegExp(
+                `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
+                'm'
+              );
+            }
+            function parseWorkflowState(body, key) {
+              const match = (body || '').match(getLinePattern(key));
+              if (!match) return { selected: false };
+              return { selected: match[1] === 'x', statusText: match[2] || null };
+            }
+            function parseMenuState(body) {
+              const state = {};
+              for (const key of WORKFLOW_ORDER) state[key] = parseWorkflowState(body, key);
+              return state;
+            }
+            function getStatusText(workflowState, workflowStatus) {
+              if (workflowStatus?.statusText) return workflowStatus.statusText;
+              const progressLink = workflowStatus?.detailsUrl ? ` [View progress](${workflowStatus.detailsUrl}).` : '';
+              if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') return `Status: running.${progressLink}`;
+              if (workflowStatus?.status === 'completed') {
+                if (workflowStatus.conclusion === 'success') return `Status: completed.${progressLink}`;
+                if (workflowStatus.conclusion === 'cancelled') return `Status: cancelled.${progressLink}`;
+                return `Status: needs attention.${progressLink}`;
+              }
+              if (workflowState?.selected) return 'Status: queued.';
+              return 'Status: not started.';
+            }
+            function getWorkflowStatusFromCheckRuns(key, checkRuns) {
+              const { checkNamePrefix } = WORKFLOW_CONFIG[key];
+              const matchingCheckRuns = (checkRuns || []).filter((cr) =>
+                cr.name?.startsWith(checkNamePrefix) && cr.conclusion !== 'skipped'
+              );
+              if (matchingCheckRuns.length === 0) return null;
+              matchingCheckRuns.sort((l, r) =>
+                new Date(r.started_at || r.created_at || 0) - new Date(l.started_at || l.created_at || 0)
+              );
+              return {
+                conclusion: matchingCheckRuns[0].conclusion,
+                detailsUrl: matchingCheckRuns[0].details_url,
+                status: matchingCheckRuns[0].status,
+              };
+            }
+            function buildWorkflowLine(key, workflowState, workflowStatus) {
+              const { label, marker } = WORKFLOW_CONFIG[key];
+              const selected = workflowState?.selected ? 'x' : ' ';
+              const statusText = getStatusText(workflowState, workflowStatus);
+              return `- [${selected}] ${label} ${statusText} ${marker}`;
+            }
+            function buildMenuBody(state, statuses) {
+              const normalizedState = state || {};
+              const normalizedStatuses = statuses || {};
+              return [
+                MENU_START,
+                '## Elastic Docs AI PR menu',
+                '',
+                'Check the box to run an AI review for this pull request.',
+                '',
+                ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key], normalizedStatuses[key])),
+                '',
+                'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
+                '',
+                MENU_END,
+              ].join('\n');
+            }
+            async function getCheckRunsForPullRequest(github, context, pullRequestNumber) {
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner, repo: context.repo.repo, pull_number: pullRequestNumber,
+              });
+              const { data: checks } = await github.rest.checks.listForRef({
+                owner: context.repo.owner, repo: context.repo.repo,
+                ref: pullRequest.head.sha, per_page: 100,
+              });
+              return checks.check_runs || [];
+            }
+            async function findMenuComment(github, context, pullRequestNumber) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pullRequestNumber, per_page: 100,
+              });
+              return comments.find((c) =>
+                c.user?.login === 'github-actions[bot]' &&
+                c.body?.includes(MENU_START) && c.body?.includes(MENU_END)
+              );
+            }
+            function getActiveWorkflowStatusFromState(workflowState) {
+              if (workflowState?.statusText?.startsWith('Status: running.')) {
+                return { statusText: workflowState.statusText };
+              }
+              return null;
+            }
+            function buildWorkflowStatuses(checkRuns, statusOverrides, existingState) {
+              return Object.fromEntries(
+                WORKFLOW_ORDER.map((key) => [
+                  key,
+                  statusOverrides?.[key] ||
+                    getWorkflowStatusFromCheckRuns(key, checkRuns) ||
+                    getActiveWorkflowStatusFromState(existingState?.[key]),
+                ])
+              );
+            }
+            async function upsertMenuComment({ core, createIfMissing = true, github, context, pullRequestNumber, statusOverrides }) {
+              const checkRuns = await getCheckRunsForPullRequest(github, context, pullRequestNumber);
+              const existingComment = await findMenuComment(github, context, pullRequestNumber);
+              if (!existingComment && !createIfMissing) {
+                core?.warning('AI PR menu comment was not found.');
+                return;
+              }
+              const existingState = parseMenuState(existingComment?.body || '');
+              const statuses = buildWorkflowStatuses(checkRuns, statusOverrides, existingState);
+              const body = buildMenuBody(existingState, statuses);
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existingComment.id, body,
+                });
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pullRequestNumber, body,
+              });
+            }
+            // ─── End helpers ───
+
+            const pullRequestNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const docsReviewResult = '${{ needs.run-docs-review.result }}';
+
+            await upsertMenuComment({
+              core, createIfMissing: false, github, context, pullRequestNumber,
+              statusOverrides: {
+                docsReview: {
+                  conclusion: docsReviewResult === 'success' ? 'success' : docsReviewResult === 'cancelled' ? 'cancelled' : 'failure',
+                  detailsUrl: progressUrl,
+                  status: 'completed',
+                },
+              },
+            });

--- a/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
@@ -6,8 +6,9 @@ name: Docs PR AI menu
 # (no .github/scripts/ dependency in target repos).
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_run:
+    workflows: ["Docs PR AI menu (collect)"]
+    types: [completed]
   issue_comment:
     types: [edited]
   workflow_dispatch:
@@ -29,7 +30,7 @@ jobs:
   post-menu:
     name: Post or refresh AI PR menu
     if: >-
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -38,12 +39,31 @@ jobs:
       issues: write
       pull-requests: write
     concurrency:
-      group: docs-pr-ai-menu-${{ github.event.pull_request.number || github.event.inputs.pull_request_number }}
+      group: docs-pr-ai-menu-${{ github.event.workflow_run.id || github.event.inputs.pull_request_number }}
       cancel-in-progress: false
 
     steps:
+      - name: Download PR number artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve pull request number
+        id: resolve-pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.inputs.pull_request_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create or update AI PR menu comment
         uses: actions/github-script@v9.0.0
+        env:
+          PULL_REQUEST_NUMBER: ${{ steps.resolve-pr.outputs.number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -187,13 +207,10 @@ jobs:
             }
             // ─── End helpers ───
 
-            const workflowDispatchPrNumber = context.payload.inputs?.pull_request_number;
-            const pullRequestNumber = context.eventName === 'workflow_dispatch'
-              ? Number(workflowDispatchPrNumber)
-              : context.payload.pull_request.number;
+            const pullRequestNumber = Number(process.env.PULL_REQUEST_NUMBER);
 
             if (!pullRequestNumber) {
-              core.setFailed('Pull request number is required for workflow_dispatch runs.');
+              core.setFailed('Pull request number is required.');
               return;
             }
 

--- a/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
@@ -28,7 +28,9 @@ permissions:
 jobs:
   post-menu:
     name: Post or refresh AI PR menu
-    if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'
+    if: >-
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       checks: read

--- a/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
@@ -228,6 +228,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       docs_review_triggered: ${{ steps.evaluate.outputs.docs_review_triggered }}
 
@@ -271,6 +272,16 @@ jobs:
 
             const body = context.payload.comment.body || '';
             const previousBody = context.payload.changes?.body?.from || '';
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            if (pullRequest.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setOutput('docs_review_triggered', 'false');
+              return;
+            }
 
             const previousState = parseMenuState(previousBody);
             const currentState = parseMenuState(body);

--- a/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Download PR number artifact
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pr-number
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu.yml
@@ -278,9 +278,22 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.issue.number,
             });
-            if (pullRequest.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
-              core.setOutput('docs_review_triggered', 'false');
-              return;
+            const isForkPR = pullRequest.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
+            if (isForkPR) {
+              let isOrgMember = false;
+              try {
+                const { status } = await github.rest.orgs.checkMembershipForUser({
+                  org: context.repo.owner,
+                  username: context.actor,
+                });
+                isOrgMember = status === 204;
+              } catch {
+                isOrgMember = false;
+              }
+              if (!isOrgMember) {
+                core.setOutput('docs_review_triggered', 'false');
+                return;
+              }
             }
 
             const previousState = parseMenuState(previousBody);


### PR DESCRIPTION
## Summary

Implements the split-workflow pattern to fix SEC-043 while preserving the AI PR menu for **all** PRs, including forks.

**The problem with `pull_request_target`:** it runs in the base repo context with write-capable `GITHUB_TOKEN`, which is dangerous when the triggering PR could come from an untrusted fork — even if the workflow doesn't check out code, having write permissions reachable from fork PRs is flagged by zizmor as a dangerous trigger.

**The split-workflow pattern:**
1. **`docs-pr-ai-menu-collect.yml`** (new) — triggered by `pull_request` (fork-safe, read-only, no secrets). Its only job is to save the PR number as an artifact.
2. **`docs-pr-ai-menu.yml`** (updated) — now triggered by `workflow_run` on the collect workflow. Runs in the trusted base-repo context, downloads the PR number artifact, and posts the menu comment. No untrusted code is ever executed under write-capable permissions.

This fully restores fork PR support (which the previous same-repo guard dropped) while eliminating the SEC-043 finding.

## Test plan

- [ ] Open a same-repo PR → collect workflow runs, then main workflow picks up the PR number and posts the AI PR menu comment.
- [ ] Open a fork PR → collect workflow runs (read-only), then main workflow posts the menu on the fork PR too.
- [ ] `workflow_dispatch` with a PR number → still works (bypasses the collect step entirely).
- [ ] The security detector (`gh-aw-security-detector`) no longer emits SEC-043 for `docs-pr-ai-menu.yml`.

Fixes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)