### PR TITLE
feat(automerge): gate approval by active dependency collections

### DIFF
--- a/.github/workflows/gh-aw-automerge.yml
+++ b/.github/workflows/gh-aw-automerge.yml
@@ -25,13 +25,20 @@ jobs:
     outputs:
       proceed: ${{ steps.validate.outputs.proceed }}
     steps:
-      - name: Checkout elastic/oblt-aw (automerge TypeScript)
+      - name: Checkout elastic/oblt-aw (automerge verify only)
         uses: actions/checkout@v6
         with:
           repository: elastic/oblt-aw
           ref: main
           path: _oblt-aw
+          fetch-depth: 1
           token: ${{ github.token }}
+          sparse-checkout: |
+            config/obs/allowed_pr_authors.json
+            scripts/obs/validateAutomergePr.ts
+            package.json
+            package-lock.json
+          sparse-checkout-cone-mode: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -62,9 +69,71 @@ jobs:
             const { ok } = await run({ github, context, prNumber, core });
             core.setOutput('proceed', ok ? 'true' : 'false');
 
-  approve:
+  # Classify dependency updates by changed file paths (no extra labels in consumer repos).
+  # Posts a single PR comment when the collection is inactive, ambiguous, or unclassified.
+  check-dependency-collection:
     needs: verify
     if: needs.verify.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      allowed: ${{ steps.check-collection.outputs.allowed }}
+      collection-id: ${{ steps.check-collection.outputs.collection-id }}
+    steps:
+      - name: Checkout elastic/oblt-aw (dependency collection gate only)
+        uses: actions/checkout@v6
+        with:
+          repository: elastic/oblt-aw
+          ref: main
+          path: _oblt-aw
+          fetch-depth: 1
+          token: ${{ github.token }}
+          sparse-checkout: |
+            config/obs/automerge-dependency-collections.json
+            scripts/obs/checkAutomergeDependencyCollection.ts
+            scripts/obs/classifyAutomergeDependencyCollection.ts
+            scripts/obs/lib/matchPathGlob.ts
+            package.json
+            package-lock.json
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: _oblt-aw/package-lock.json
+
+      - name: Install npm dependencies
+        working-directory: _oblt-aw
+        run: npm ci
+
+      - name: Check dependency collection for automerge
+        id: check-collection
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const path = require('node:path');
+            const { createRequire } = require('node:module');
+            const root = path.join(process.env.GITHUB_WORKSPACE, '_oblt-aw');
+            const rq = createRequire(path.join(root, 'package.json'));
+            rq('tsx/cjs/api').register();
+            const { run } = rq('./scripts/obs/checkAutomergeDependencyCollection.ts');
+            const prNumber = parseInt(process.env.PR_NUMBER || '', 10);
+            const { allowed, collectionId } = await run({ github, context, prNumber, core });
+            core.setOutput('allowed', allowed ? 'true' : 'false');
+            core.setOutput('collection-id', collectionId || '');
+
+  approve:
+    needs: [verify, check-dependency-collection]
+    if: >-
+      needs.verify.outputs.proceed == 'true' &&
+      needs.check-dependency-collection.outputs.allowed == 'true'
     permissions:
       actions: read
       contents: write
@@ -79,7 +148,7 @@ jobs:
       prompt: |
         For pull request #${{ github.event.pull_request.number }}: evaluate automerge eligibility.
 
-        This PR already passed automerge validation in the workflow (GITHUB_TOKEN) for author, label, draft/fork/ref.
+        This PR already passed automerge validation in the workflow (GITHUB_TOKEN) for author, label, draft/fork/ref, and dependency collection `${{ needs.check-dependency-collection.outputs.collection-id }}` (file-path classification; no extra repo labels).
         Do not call check-run or commit status APIs. Required checks are enforced by GitHub when auto-merge is enabled.
 
         Approve the PR only when all of these gates are true:
@@ -99,8 +168,11 @@ jobs:
   automerge:
     needs:
       - verify
+      - check-dependency-collection
       - approve
-    if: needs.verify.outputs.proceed == 'true'
+    if: >-
+      needs.verify.outputs.proceed == 'true' &&
+      needs.check-dependency-collection.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/config/obs/automerge-dependency-collections.json
+++ b/config/obs/automerge-dependency-collections.json
@@ -1,0 +1,69 @@
+{
+  "version": 1,
+  "policy": "deny-unclassified",
+  "collections": [
+    {
+      "id": "github-actions",
+      "description": "GitHub Actions and composite action version bumps",
+      "active": true,
+      "file-glob": [
+        ".github/workflows/**",
+        ".github/actions/**",
+        "**/action.yml",
+        "**/action.yaml"
+      ]
+    },
+    {
+      "id": "pre-commit",
+      "description": "pre-commit hook dependency updates",
+      "active": true,
+      "file-glob": [".pre-commit-config.yaml"]
+    },
+    {
+      "id": "python-dependencies",
+      "description": "Python package and lockfile updates",
+      "active": false,
+      "file-glob": [
+        "**/pyproject.toml",
+        "**/requirements.txt",
+        "**/requirements-*.txt",
+        "**/poetry.lock",
+        "**/Pipfile",
+        "**/Pipfile.lock"
+      ]
+    },
+    {
+      "id": "go-dependencies",
+      "description": "Go module and sum updates",
+      "active": false,
+      "file-glob": ["go.mod", "go.sum", "**/go.mod", "**/go.sum"]
+    },
+    {
+      "id": "node-dependencies",
+      "description": "npm/yarn/pnpm manifest and lockfile updates",
+      "active": false,
+      "file-glob": [
+        "package.json",
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "**/package.json",
+        "**/package-lock.json",
+        "**/yarn.lock",
+        "**/pnpm-lock.yaml"
+      ]
+    },
+    {
+      "id": "vm-images",
+      "description": "CI runner or container image pin updates",
+      "active": false,
+      "file-glob": [
+        ".buildkite/**",
+        "**/Dockerfile",
+        "**/Dockerfile.*",
+        "**/docker-compose.yml",
+        "**/docker-compose.yaml"
+      ]
+    }
+  ]
+}

--- a/docs/routing/automerge-routing.md
+++ b/docs/routing/automerge-routing.md
@@ -4,7 +4,7 @@
 
 Entrypoint source: `.github/workflows/oblt-aw-ingress.yml`
 
-Routed workflow source: `.github/workflows/gh-aw-automerge.yml` (`verify`, `approve`, `automerge`, and conditional `enable-merge-when-ready` on the PR). Merge first uses **pascalgn/automerge-action** with `GITHUB_TOKEN`; when that step reports `merge_failed`, the workflow enables native GitHub auto-merge as a fallback.
+Routed workflow source: `.github/workflows/gh-aw-automerge.yml` (`verify`, `check-dependency-collection`, `approve`, `automerge`, and conditional `enable-merge-when-ready` on the PR). Merge first uses **pascalgn/automerge-action** with `GITHUB_TOKEN`; when that step reports `merge_failed`, the workflow enables native GitHub auto-merge as a fallback.
 
 ## Usage
 
@@ -31,6 +31,14 @@ The client entrypoint must include `labeled` in `pull_request` types (see the di
 | PR state | Not a draft |
 | Branch origin | Upstream branch (head repo equals base repo — not a fork) |
 | Refs | Head ref ≠ base ref |
+
+**`gh-aw-automerge.yml` — `check-dependency-collection` job** (`scripts/obs/checkAutomergeDependencyCollection.ts`):
+
+| Requirement | Details |
+|---------------|---------|
+| Classification | Changed file paths on the PR are matched against [config/obs/automerge-dependency-collections.json](../../config/obs/automerge-dependency-collections.json) (`file-glob` per collection). No extra labels are required in consumer repositories. |
+| Active collections | Only collections with `"active": true` proceed to `approve` and `automerge`. |
+| Skipped PRs | When classification fails or the collection is inactive, the job posts or updates a single PR comment (marker `oblt-aw-automerge:dependency-collection-gate`) and downstream jobs do not run. |
 
 **`automerge` job** (after approval): **[pascalgn/automerge-action](https://github.com/pascalgn/automerge-action)** enforces `MERGE_LABELS` (`oblt-aw/ai/merge-ready`), `MERGE_REQUIRED_APPROVALS`, fork/branch settings, and merges with **squash** when GitHub reports the PR as ready (required checks and reviews per branch protection and action config). Author and label gates are enforced in `verify` (`validateAutomergePr.ts`, same allow list as dependency-review).
 

--- a/docs/workflows/gh-aw-automerge.md
+++ b/docs/workflows/gh-aw-automerge.md
@@ -17,8 +17,9 @@ Ingress selects which events dispatch here; see [Automerge routing](../routing/a
 
 Jobs:
 
-- `verify`: checks out control-plane scripts, runs `scripts/obs/validateAutomergePr.ts` for `github.event.pull_request.number` (author allow list aligned with dependency-review, merge-ready label, draft/fork/ref).
-- `approve`: invokes `elastic/ai-github-actions` `gh-aw-mention-in-pr.lock.yml` when `verify` sets `proceed` (Copilot must not call check-run APIs for gating; branch protection handles required checks at merge time).
+- `verify`: shallow sparse checkout of `elastic/oblt-aw` (`allowed_pr_authors.json`, `validateAutomergePr.ts`, and npm manifests only), then runs `scripts/obs/validateAutomergePr.ts` for `github.event.pull_request.number` (author allow list aligned with dependency-review, merge-ready label, draft/fork/ref).
+- `check-dependency-collection`: shallow sparse checkout of `elastic/oblt-aw` (collection config, gate scripts, and `package.json` / lockfile only), then classifies the PR by changed file paths against [config/obs/automerge-dependency-collections.json](../../config/obs/automerge-dependency-collections.json); skips `approve`/`automerge` when the collection is not active and posts a PR comment explaining why (no extra labels in target repos).
+- `approve`: invokes `elastic/ai-github-actions` `gh-aw-mention-in-pr.lock.yml` when `verify` and `check-dependency-collection` pass (Copilot must not call check-run APIs for gating; branch protection handles required checks at merge time).
 - `automerge`: runs **pascalgn/automerge-action** with `GITHUB_TOKEN` on the **same** repository as the PR (`PULL_REQUEST` is the PR number). Squash-merge when `MERGE_LABELS`, `MERGE_REQUIRED_APPROVALS`, and GitHub mergeability align with branch protection.
 - `enable-merge-when-ready`: runs only when `automerge` outputs `merge_failed`; creates an ephemeral token via `elastic/oblt-actions/github/create-token@v1` and enables native auto-merge queue behavior with `gh pr merge --auto --squash`.
 
@@ -32,6 +33,7 @@ There is no discover step. Ingress passes **`allowed-bot-users`** (CSV from `loa
 |-----|-------------|
 | Workflow (default) | `contents: read` |
 | `verify` | `actions: read`, `contents: read`, `pull-requests: read` (validate script reads the PR) |
+| `check-dependency-collection` | `contents: read`, `pull-requests: write` (list PR files, post or remove gate comment) |
 | `approve` | `actions: read`, `contents: write`, `discussions: write`, `issues: write`, `pull-requests: write` (GH-AW mention-in-pr) |
 | `automerge` | `contents: write`, `pull-requests: write` (automerge action merges the PR) |
 | `enable-merge-when-ready` | `id-token: write` (required for ephemeral token minting before `gh pr merge --auto`) |

--- a/scripts/obs/checkAutomergeDependencyCollection.ts
+++ b/scripts/obs/checkAutomergeDependencyCollection.ts
@@ -1,0 +1,134 @@
+// Copyright 2026-2027 Elasticsearch B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Classifies a dependency-update PR by changed file paths (no extra repo labels),
+ * allows automerge only for active collections in
+ * `config/obs/automerge-dependency-collections.json`, and posts or removes a
+ * single gate comment on the PR when automerge is skipped.
+ */
+const {
+  GATE_COMMENT_MARKER,
+  activeCollectionIds,
+  buildGateCommentBody,
+  classifyChangedFiles,
+  loadCollectionsConfig,
+} = require('./classifyAutomergeDependencyCollection.ts');
+
+async function listPullRequestFilePaths(github, owner, repo, prNumber) {
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+  return files.map((f) => f.filename);
+}
+
+async function findGateComment(github, owner, repo, prNumber) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: prNumber,
+  });
+  return comments.find((c) => (c.body || '').includes(GATE_COMMENT_MARKER)) || null;
+}
+
+async function upsertGateComment(github, owner, repo, prNumber, body) {
+  const existing = await findGateComment(github, owner, repo, prNumber);
+  if (existing) {
+    if ((existing.body || '').trim() === body.trim()) {
+      return;
+    }
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body,
+    });
+    return;
+  }
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body,
+  });
+}
+
+async function removeGateCommentIfPresent(github, owner, repo, prNumber) {
+  const existing = await findGateComment(github, owner, repo, prNumber);
+  if (!existing) {
+    return;
+  }
+  await github.rest.issues.deleteComment({
+    owner,
+    repo,
+    comment_id: existing.id,
+  });
+}
+
+module.exports.run = async function run({ github, context, prNumber, core }) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+
+  if (typeof prNumber !== 'number' || !Number.isFinite(prNumber)) {
+    core.info('Automerge collection gate: invalid PR number; skipping.');
+    return { allowed: false, collectionId: '' };
+  }
+
+  const config = loadCollectionsConfig();
+  const collections = config.collections || [];
+  const activeIds = activeCollectionIds(collections);
+
+  const changedFiles = await listPullRequestFilePaths(
+    github,
+    owner,
+    repo,
+    prNumber
+  );
+  const outcome = classifyChangedFiles(changedFiles, collections);
+
+  if (outcome.status === 'allowed') {
+    core.info(
+      `PR #${prNumber}: dependency collection '${outcome.collectionId}' is active for automerge`
+    );
+    await removeGateCommentIfPresent(github, owner, repo, prNumber);
+    return { allowed: true, collectionId: outcome.collectionId };
+  }
+
+  const collectionId =
+    outcome.status === 'ambiguous'
+      ? outcome.collectionIds.join(',')
+      : outcome.collectionId || '';
+
+  const commentBody = buildGateCommentBody(outcome, changedFiles, activeIds);
+  await upsertGateComment(github, owner, repo, prNumber, commentBody);
+
+  if (outcome.status === 'inactive') {
+    core.info(
+      `PR #${prNumber}: collection '${outcome.collectionId}' is not active for automerge; posted gate comment`
+    );
+  } else if (outcome.status === 'ambiguous') {
+    core.info(
+      `PR #${prNumber}: ambiguous collections [${outcome.collectionIds.join(', ')}]; posted gate comment`
+    );
+  } else {
+    core.info(
+      `PR #${prNumber}: unclassified dependency collection; posted gate comment`
+    );
+  }
+
+  return { allowed: false, collectionId };
+};

--- a/scripts/obs/classifyAutomergeDependencyCollection.ts
+++ b/scripts/obs/classifyAutomergeDependencyCollection.ts
@@ -1,0 +1,156 @@
+// Copyright 2026-2027 Elasticsearch B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const path = require('node:path');
+const fs = require('node:fs');
+
+const { pathMatchesAnyGlob } = require('./lib/matchPathGlob.ts');
+
+const GATE_COMMENT_MARKER = '<!-- oblt-aw-automerge:dependency-collection-gate -->';
+
+/** @typedef {object} DependencyCollection
+ * @property {string} id
+ * @property {string} [description]
+ * @property {boolean} active
+ * @property {string[]} file-glob
+ */
+
+/** @typedef {object} CollectionsConfig
+ * @property {number} version
+ * @property {string} policy
+ * @property {DependencyCollection[]} collections
+ */
+
+/** @typedef {object} ClassificationOutcomeAllowed
+ * @property {'allowed'} status
+ * @property {string} collectionId
+ */
+
+/** @typedef {object} ClassificationOutcomeInactive
+ * @property {'inactive'} status
+ * @property {string} collectionId
+ */
+
+/** @typedef {object} ClassificationOutcomeUnclassified
+ * @property {'unclassified'} status
+ * @property {null} collectionId
+ */
+
+/** @typedef {object} ClassificationOutcomeAmbiguous
+ * @property {'ambiguous'} status
+ * @property {string[]} collectionIds
+ */
+
+/** @typedef {ClassificationOutcomeAllowed|ClassificationOutcomeInactive|ClassificationOutcomeUnclassified|ClassificationOutcomeAmbiguous} ClassificationOutcome
+ */
+
+const CONFIG_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'config',
+  'obs',
+  'automerge-dependency-collections.json'
+);
+
+function loadCollectionsConfig(configPath = CONFIG_PATH) {
+  return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+function activeCollectionIds(collections) {
+  return collections.filter((c) => c.active).map((c) => c.id);
+}
+
+function collectionMatchesAllFiles(collection, files) {
+  if (files.length === 0) {
+    return false;
+  }
+  const globs = collection['file-glob'] || [];
+  return files.every((file) => pathMatchesAnyGlob(file, globs));
+}
+
+function classifyChangedFiles(files, collections) {
+  const changed = [...new Set(files.map((f) => f.trim()).filter(Boolean))];
+  if (changed.length === 0) {
+    return { status: 'unclassified', collectionId: null };
+  }
+
+  const matched = collections.filter((c) =>
+    collectionMatchesAllFiles(c, changed)
+  );
+
+  if (matched.length === 0) {
+    return { status: 'unclassified', collectionId: null };
+  }
+  if (matched.length > 1) {
+    return {
+      status: 'ambiguous',
+      collectionIds: matched.map((c) => c.id),
+    };
+  }
+
+  const collection = matched[0];
+  if (collection.active) {
+    return { status: 'allowed', collectionId: collection.id };
+  }
+  return { status: 'inactive', collectionId: collection.id };
+}
+
+function buildGateCommentBody(outcome, changedFiles, activeIds) {
+  const activeList =
+    activeIds.length > 0
+      ? activeIds.map((id) => `\`${id}\``).join(', ')
+      : '_(none configured)_';
+  const fileSample = changedFiles.slice(0, 20);
+  const fileLines = fileSample.map((f) => `- \`${f}\``).join('\n');
+  const fileSuffix =
+    changedFiles.length > fileSample.length
+      ? `\n- _…and ${changedFiles.length - fileSample.length} more_`
+      : '';
+
+  let reason = '';
+  if (outcome.status === 'inactive') {
+    reason = `This pull request was classified as **\`${outcome.collectionId}\`**. The Observability automerge workflow does not support that dependency collection.`;
+  } else if (outcome.status === 'unclassified') {
+    reason =
+      'This pull request could not be matched to any configured dependency collection from its changed files.';
+  } else if (outcome.status === 'ambiguous') {
+    reason = `This pull request matched multiple dependency collections: ${outcome.collectionIds.map((id) => `\`${id}\``).join(', ')}. Automerge requires an unambiguous classification.`;
+  }
+
+  return [
+    GATE_COMMENT_MARKER,
+    '',
+    '### Automerge skipped (dependency collection)',
+    '',
+    reason,
+    '',
+    `**Collections enabled for automerge:** ${activeList}`,
+    '',
+    'Dependency-review may still have applied `oblt-aw/ai/merge-ready` for risk review. Only allow-listed collections proceed to Copilot approval and merge via this workflow.',
+    '',
+    '**Changed files considered for classification:**',
+    fileLines || '- _(none)_',
+    fileSuffix,
+  ].join('\n');
+}
+
+module.exports = {
+  GATE_COMMENT_MARKER,
+  loadCollectionsConfig,
+  activeCollectionIds,
+  classifyChangedFiles,
+  buildGateCommentBody,
+};

--- a/scripts/obs/lib/matchPathGlob.ts
+++ b/scripts/obs/lib/matchPathGlob.ts
@@ -1,0 +1,64 @@
+// Copyright 2026-2027 Elasticsearch B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Match a repository-relative path against a glob (supports `*` and `**`).
+ */
+function globPatternToRegExp(pattern: string): RegExp {
+  const normalized = pattern.replace(/\\/g, '/').replace(/^\.\//, '');
+  let re = '^';
+  for (let i = 0; i < normalized.length; i += 1) {
+    const ch = normalized[i];
+    const next = normalized[i + 1];
+    if (ch === '*' && next === '*') {
+      const after = normalized[i + 2];
+      if (after === '/') {
+        re += '(?:.*/)?';
+        i += 2;
+      } else {
+        re += '.*';
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === '*') {
+      re += '[^/]*';
+      continue;
+    }
+    if ('.+^${}()|[]\\'.includes(ch)) {
+      re += `\\${ch}`;
+      continue;
+    }
+    re += ch;
+  }
+  re += '$';
+  return new RegExp(re);
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function matchPathGlob(filePath: string, pattern: string): boolean {
+  const path = normalizePath(filePath);
+  const pat = pattern.replace(/\\/g, '/');
+  return globPatternToRegExp(pat).test(path);
+}
+
+function pathMatchesAnyGlob(filePath: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => matchPathGlob(filePath, pattern));
+}
+
+module.exports = { matchPathGlob, pathMatchesAnyGlob };

--- a/tests/unit/classifyAutomergeDependencyCollection.test.ts
+++ b/tests/unit/classifyAutomergeDependencyCollection.test.ts
@@ -1,0 +1,108 @@
+// Copyright 2026-2027 Elasticsearch B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// @ts-nocheck
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  classifyChangedFiles,
+  buildGateCommentBody,
+  activeCollectionIds,
+} = require('../../scripts/obs/classifyAutomergeDependencyCollection.ts');
+
+const COLLECTIONS = [
+  {
+    id: 'github-actions',
+    active: true,
+    'file-glob': ['.github/workflows/**'],
+  },
+  {
+    id: 'python-dependencies',
+    active: false,
+    'file-glob': ['**/pyproject.toml'],
+  },
+];
+
+test('classifyChangedFiles allows active github-actions-only PR', () => {
+  const outcome = classifyChangedFiles(
+    ['.github/workflows/gh-aw-automerge.yml'],
+    COLLECTIONS
+  );
+  assert.deepEqual(outcome, {
+    status: 'allowed',
+    collectionId: 'github-actions',
+  });
+});
+
+test('classifyChangedFiles allows active pre-commit-only PR', () => {
+  const collections = [
+    ...COLLECTIONS,
+    {
+      id: 'pre-commit',
+      active: true,
+      'file-glob': ['.pre-commit-config.yaml'],
+    },
+  ];
+  const outcome = classifyChangedFiles(['.pre-commit-config.yaml'], collections);
+  assert.deepEqual(outcome, {
+    status: 'allowed',
+    collectionId: 'pre-commit',
+  });
+});
+
+test('classifyChangedFiles rejects inactive python collection', () => {
+  const outcome = classifyChangedFiles(['pyproject.toml'], COLLECTIONS);
+  assert.deepEqual(outcome, {
+    status: 'inactive',
+    collectionId: 'python-dependencies',
+  });
+});
+
+test('classifyChangedFiles is unclassified when no collection matches', () => {
+  const outcome = classifyChangedFiles(['README.md'], COLLECTIONS);
+  assert.deepEqual(outcome, {
+    status: 'unclassified',
+    collectionId: null,
+  });
+});
+
+test('classifyChangedFiles is ambiguous when multiple collections match', () => {
+  const collections = [
+    ...COLLECTIONS,
+    {
+      id: 'also-workflows',
+      active: false,
+      'file-glob': ['.github/workflows/**'],
+    },
+  ];
+  const outcome = classifyChangedFiles(
+    ['.github/workflows/x.yml'],
+    collections
+  );
+  assert.equal(outcome.status, 'ambiguous');
+  assert.equal(outcome.collectionIds.length, 2);
+});
+
+test('buildGateCommentBody includes inactive collection and active list', () => {
+  const body = buildGateCommentBody(
+    { status: 'inactive', collectionId: 'python-dependencies' },
+    ['pyproject.toml'],
+    activeCollectionIds(COLLECTIONS)
+  );
+  assert.match(body, /python-dependencies/);
+  assert.match(body, /github-actions/);
+  assert.match(body, /dependency-collection-gate/);
+});

--- a/tests/unit/matchPathGlob.test.ts
+++ b/tests/unit/matchPathGlob.test.ts
@@ -1,0 +1,39 @@
+// Copyright 2026-2027 Elasticsearch B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// @ts-nocheck
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { matchPathGlob, pathMatchesAnyGlob } = require('../../scripts/obs/lib/matchPathGlob.ts');
+
+test('matchPathGlob matches workflow paths', () => {
+  assert.equal(
+    matchPathGlob('.github/workflows/gh-aw-automerge.yml', '.github/workflows/**'),
+    true
+  );
+  assert.equal(matchPathGlob('README.md', '.github/workflows/**'), false);
+});
+
+test('matchPathGlob matches action manifests', () => {
+  assert.equal(matchPathGlob('composite/action.yml', '**/action.yml'), true);
+});
+
+test('pathMatchesAnyGlob accepts multiple patterns', () => {
+  assert.equal(
+    pathMatchesAnyGlob('go.mod', ['**/pyproject.toml', 'go.mod']),
+    true
+  );
+});


### PR DESCRIPTION
## Summary

- Add `check-dependency-collection` to `gh-aw-automerge.yml`: classifies bot dependency PRs by changed file paths against `config/obs/automerge-dependency-collections.json` (no extra labels in consumer repos).
- Only **active** collections proceed to Copilot approval and automerge; inactive, ambiguous, or unclassified PRs get a single explanatory PR comment and skip downstream jobs.
- **Active today:** `github-actions`, `pre-commit`.
- Shallow sparse checkout in `verify` and `check-dependency-collection` to minimize clone size.

## Flow

```mermaid
flowchart TD
  DR[dependency-review] --> MR[oblt-aw/ai/merge-ready]
  IN[ingress] --> V[verify: validateAutomergePr]
  V --> C[check-dependency-collection]
  C -->|allowed| A[approve]
  C -->|not allowed| X[PR gate comment + skip approve/automerge]
  A --> M[automerge]
```

## Test plan

- [x] `npm test` (15 unit tests)
- [ ] Merge a github-actions-only Dependabot/Renovate PR with `oblt-aw/ai/merge-ready` and confirm approve/automerge run
- [ ] Merge a python-only dependency PR with merge-ready and confirm gate comment + no approve/automerge
- [ ] Confirm gate comment is updated (not duplicated) on re-run

Related issue: https://github.com/elastic/observability-robots/issues/4425
