### PR TITLE
revert: remove legacy trg-* deletion

### DIFF
--- a/docs/operations/distribute-client-workflow.md
+++ b/docs/operations/distribute-client-workflow.md
@@ -77,7 +77,6 @@ Behavior:
 - If `CHANGED_FILES_COUNT == 0`, `FORCE_DISTRIBUTION` is false, and `git diff --name-only` between `BASE_REF` and `HEAD` under `config/` and `.github/remote-workflow-template/` is empty, returns no targets. The git fallback covers template **renames** (the changed-files action only counts added, modified, and deleted paths).
 - Always generates `install` operations for repositories in the current union of per-org lists (see [scripts/build_target_operations.py](../../scripts/build_target_operations.py)).
 - Each `install` target includes `remove_files`: destination paths that existed in the template tree at `BASE_REF` for that repository’s org assignments but are absent from the current tree.
-- For Observability client workflows, `remove_files` also includes legacy `trg-oblt-aw-*.yml` paths derived from the current `trigger-oblt-aw-*.yml` set, so a previously-skipped rename distribution can still clean up stale `trg-*` files in consumer repositories.
 - Generates `remove` operations for repositories present at `BASE_REF` but absent from current config.
 
 Workflow outputs written by the script:

--- a/scripts/build_target_operations.py
+++ b/scripts/build_target_operations.py
@@ -120,23 +120,6 @@ def parse_bool(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def legacy_trg_client_entrypoints(current_dsts: set[str]) -> set[str]:
-    """
-    Derive legacy `trg-` client entrypoint paths from the current `trigger-` set.
-
-    This handles the case where a rename-only template change was skipped by the
-    distribution workflow (for example because the changed-files action ignores
-    git renames), leaving stale `trg-*` files in target repositories. When the
-    current template tree contains `trigger-*`, we proactively delete the
-    corresponding `trg-*` paths.
-    """
-    legacy: set[str] = set()
-    for dst in current_dsts:
-        if dst.startswith(".github/workflows/trigger-oblt-aw-"):
-            legacy.add(dst.replace("/trigger-oblt-aw-", "/trg-oblt-aw-", 1))
-    return legacy
-
-
 def has_relevant_git_changes(base_ref: str) -> bool:
     """
     True when ``config/`` or the remote template tree differ between ``base_ref`` and HEAD.
@@ -234,9 +217,7 @@ def main() -> int:
             previous_assignments.get(repo, []), at_base_ref=True
         )
         current_dsts = dst_paths(files)
-        removed_by_template_diff = dst_paths(previous_files) - current_dsts
-        removed_legacy_trg = legacy_trg_client_entrypoints(current_dsts) - current_dsts
-        remove_files = sorted(removed_by_template_diff | removed_legacy_trg)
+        remove_files = sorted(dst_paths(previous_files) - current_dsts)
         operations.append(
             {
                 "repository": repo,

--- a/tests/test_build_target_operations.py
+++ b/tests/test_build_target_operations.py
@@ -129,25 +129,6 @@ class TestShouldRunDistribution:
         assert bto.should_run_distribution(0, False, "abc123") is False
 
 
-class TestLegacyTrgClientEntrypoints:
-    def test_maps_trigger_to_trg(self) -> None:
-        current_dsts = {
-            ".github/workflows/trigger-oblt-aw-automerge.yml",
-            ".github/workflows/trigger-oblt-aw-security-detector.yml",
-        }
-        assert bto.legacy_trg_client_entrypoints(current_dsts) == {
-            ".github/workflows/trg-oblt-aw-automerge.yml",
-            ".github/workflows/trg-oblt-aw-security-detector.yml",
-        }
-
-    def test_ignores_non_trigger_oblt_aw(self) -> None:
-        current_dsts = {
-            ".github/workflows/trigger-docs-aw-ai-menu.yml",
-            ".github/workflows/other.yml",
-        }
-        assert bto.legacy_trg_client_entrypoints(current_dsts) == set()
-
-
 class TestParseBool:
     @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes", "on"])
     def test_truthy_values(self, value: str) -> None:
@@ -263,8 +244,7 @@ class TestMain:
             dsts = {f["dst"] for f in t["files"]}
             assert ".github/workflows/trigger-oblt-aw-automerge.yml" in dsts
             assert "remove_files" in t
-            # Legacy cleanup always schedules the old trg-* path when trigger-* exists.
-            assert ".github/workflows/trg-oblt-aw-automerge.yml" in t["remove_files"]
+            assert t["remove_files"] == []
 
     def test_force_distribution(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
@@ -353,43 +333,6 @@ class TestMain:
         assert ".github/workflows/trg-oblt-aw-automerge.yml" in install["remove_files"]
         dsts = {f["dst"] for f in install["files"]}
         assert ".github/workflows/trigger-oblt-aw-automerge.yml" in dsts
-
-    def test_install_always_removes_legacy_trg_when_trigger_present(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
-    ) -> None:
-        output_file = self._setup_env(
-            monkeypatch, tmp_path, changed_files_count=1, repos=["elastic/foo"]
-        )
-        monkeypatch.setattr(
-            bto,
-            "read_previous_repo_org_assignments",
-            lambda _: {"elastic/foo": ["obs"]},
-        )
-
-        # Previous template already contains `trigger-*` so template diff alone would not
-        # schedule legacy `trg-*` deletion; we still want to remove it.
-        def fake_list_at_ref(org_key: str, ref: str) -> list[dict[str, str]]:
-            return [
-                {
-                    "src": ".github/remote-workflow-template/obs/.github/workflows/trigger-oblt-aw-automerge.yml",
-                    "dst": ".github/workflows/trigger-oblt-aw-automerge.yml",
-                },
-            ]
-
-        monkeypatch.setattr(bto, "list_org_template_files_at_ref", fake_list_at_ref)
-
-        rc = bto.main()
-        assert rc == 0
-        content = output_file.read_text()
-        targets = json.loads(
-            next(
-                line.split("=", 1)[1]
-                for line in content.splitlines()
-                if line.startswith("targets=")
-            )
-        )
-        install = next(t for t in targets if t["repository"] == "elastic/foo")
-        assert ".github/workflows/trg-oblt-aw-automerge.yml" in install["remove_files"]
 
     def test_install_includes_remove_files_for_dropped_templates(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path


### PR DESCRIPTION
## Summary

- Reverts the ad-hoc legacy `trg-oblt-aw-*.yml` cleanup that was added in #1082.
- Now that consumer repositories have already removed all `trg-*` client workflows, we can rely on the `BASE_REF` template diff only.

## Test plan

- [x] `python3 -m pytest tests/test_build_target_operations.py`

Related issue: https://github.com/elastic/observability-robots/issues/3614

Made with [Cursor](https://cursor.com)