### PR TITLE
fix(security): split-workflow for docs PR AI menu without pull_request_target (SEC-043)

### DIFF
--- a/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-pr-ai-menu-collect.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-pr-ai-menu-collect.yml
@@ -1,0 +1,18 @@
+name: Docs Agentic Workflow — AI PR Menu (collect)
+
+# Distributed to repositories in config/docs/active-repositories.json.
+# Fork-safe `pull_request` leg of the split-workflow pattern (see trigger-docs-aw-pr-ai-menu.yml).
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  collect:
+    permissions:
+      actions: write
+      contents: read
+    uses: elastic/oblt-aw/.github/workflows/docs-aw-pr-ai-menu-collect.yml@main # ratchet:exclude

--- a/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-pr-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-pr-ai-menu.yml
@@ -3,8 +3,9 @@ name: Docs Agentic Workflow — AI PR Menu
 # Distributed to repositories in config/docs/active-repositories.json.
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_run:
+    workflows: ["Docs Agentic Workflow — AI PR Menu (collect)"]
+    types: [completed]
   issue_comment:
     types: [edited]
   workflow_dispatch:
@@ -19,6 +20,9 @@ permissions:
 
 jobs:
   run-aw:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     permissions:
       actions: read
       checks: read

--- a/.github/workflows/docs-aw-pr-ai-menu-collect.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu-collect.yml
@@ -1,0 +1,32 @@
+name: Docs PR AI menu collect
+
+# Fork-safe collector for the split-workflow pattern. Consumer repositories install
+# `trigger-docs-aw-pr-ai-menu-collect.yml`, which calls this reusable on `pull_request`.
+# The PR number artifact is consumed by `docs-aw-pr-ai-menu.yml` via `workflow_run`.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  collect:
+    name: Save PR number artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Write pull request number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr_number.txt
+
+      - name: Upload pull request number artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/docs-aw-pr-ai-menu.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu.yml
@@ -27,18 +27,41 @@ jobs:
     needs: prelude
     if: >-
       needs.prelude.outputs.proceed == 'true' &&
-      (github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch')
+      (
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: read
       checks: read
       contents: read
       issues: write
       pull-requests: write
     concurrency:
-      group: docs-pr-ai-menu-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pull_request_number }}
+      group: docs-pr-ai-menu-${{ github.event.workflow_run.id || github.event.pull_request.number || github.event.issue.number || github.event.inputs.pull_request_number }}
       cancel-in-progress: false
     steps:
+      - name: Download pull request number artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve pull request number
+        id: resolve-pr
+        env:
+          WORKFLOW_DISPATCH_PR: ${{ github.event.inputs.pull_request_number }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${WORKFLOW_DISPATCH_PR}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout oblt-aw for Docs PR AI menu scripts
         uses: actions/checkout@v6
         with:
@@ -52,6 +75,8 @@ jobs:
 
       - name: Create or update AI PR menu comment
         uses: actions/github-script@v9
+        env:
+          PULL_REQUEST_NUMBER: ${{ steps.resolve-pr.outputs.number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script-path: oblt-aw-scripts/scripts/docs/pr-menu/post-menu.js
@@ -71,6 +96,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       docs_review_triggered: ${{ steps.evaluate.outputs.docs_review_triggered }}
     steps:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See [docs/development/contributing.md](docs/development/contributing.md) for ful
 Target repositories install per-workflow client templates from this repository (for example `trigger-oblt-aw-automerge.yml`, `oblt-aw-issue-fixer.yml`). Each template calls a matching `oblt-aw-*` reusable workflow; shared gating runs in [aw-prelude.yml](.github/workflows/aw-prelude.yml).
 
 - Observability templates: [.github/remote-workflow-template/obs/.github/workflows/](.github/remote-workflow-template/obs/.github/workflows/) — see [docs/workflows/oblt-aw-client-template.md](docs/workflows/oblt-aw-client-template.md)
-- Docs templates: [.github/remote-workflow-template/docs/.github/workflows/](.github/remote-workflow-template/docs/.github/workflows/) (`trigger-docs-aw-ai-menu.yml`, `trigger-docs-aw-pr-ai-menu.yml`)
+- Docs templates: [.github/remote-workflow-template/docs/.github/workflows/](.github/remote-workflow-template/docs/.github/workflows/) (`trigger-docs-aw-ai-menu.yml`, `trigger-docs-aw-pr-ai-menu-collect.yml`, `trigger-docs-aw-pr-ai-menu.yml`)
 
 ## Repository Scope
 

--- a/docs/workflows/docs-aw-client-template.md
+++ b/docs/workflows/docs-aw-client-template.md
@@ -21,9 +21,19 @@ Shared dashboard gating runs inside each `docs-aw-*` reusable workflow via [aw-p
 | Client template | Triggers | Reusable workflow |
 |-----------------|----------|-------------------|
 | `trigger-docs-aw-ai-menu.yml` | `issues` opened; `issue_comment` edited; `workflow_dispatch` (`issue_number` required) | `docs-aw-ai-menu.yml` |
-| `trigger-docs-aw-pr-ai-menu.yml` | `pull_request_target` (opened, reopened, synchronize, ready_for_review); `issue_comment` edited; `workflow_dispatch` (`pull_request_number` required) | `docs-aw-pr-ai-menu.yml` |
+| `trigger-docs-aw-pr-ai-menu-collect.yml` | `pull_request` (opened, reopened, synchronize, ready_for_review) | `docs-aw-pr-ai-menu-collect.yml` |
+| `trigger-docs-aw-pr-ai-menu.yml` | `workflow_run` on the collect workflow (completed, success only); `issue_comment` edited; `workflow_dispatch` (`pull_request_number` required) | `docs-aw-pr-ai-menu.yml` |
 
 Route-specific conditions (for example PR vs non-PR issue comments, menu checkbox transitions) are enforced inside the `docs-aw-*` reusable workflows after [aw-prelude](aw-prelude.md) runs.
+
+### Fork PRs and SEC-043 (split-workflow)
+
+Fork PRs cannot post issue comments with a write-capable `GITHUB_TOKEN` from a `pull_request` workflow. `pull_request_target` is unsafe (runs in the base repo with elevated token on untrusted fork events). The PR menu therefore uses a **split-workflow** pattern:
+
+1. **`trigger-docs-aw-pr-ai-menu-collect.yml`** — `pull_request` only; read-only job uploads a `pr-number` artifact (implementation: [docs-aw-pr-ai-menu-collect.yml](../../.github/workflows/docs-aw-pr-ai-menu-collect.yml)).
+2. **`trigger-docs-aw-pr-ai-menu.yml`** — `workflow_run` when the collect workflow completes successfully; calls [docs-aw-pr-ai-menu.yml](../../.github/workflows/docs-aw-pr-ai-menu.yml) to download the artifact and post the menu from trusted base-repo context.
+
+Menu checkbox handling (`issue_comment`) and manual refresh (`workflow_dispatch`) stay on `trigger-docs-aw-pr-ai-menu.yml`. Fork checkbox triggers require org membership (enforced in `scripts/docs/pr-menu/evaluate-trigger.js`).
 
 ## Configuration
 
@@ -38,6 +48,7 @@ Job-level permissions on `run-aw` must be at least as permissive as the union of
 | Template | `run-aw` job permissions (union of callee jobs) |
 |----------|-------------------------------------------------|
 | `trigger-docs-aw-ai-menu.yml` | `actions: read`, `contents: read`, `discussions: write`, `issues: write`, `pull-requests: write` |
+| `trigger-docs-aw-pr-ai-menu-collect.yml` | `actions: write`, `contents: read` |
 | `trigger-docs-aw-pr-ai-menu.yml` | `actions: read`, `checks: read`, `contents: read`, `issues: write`, `pull-requests: write` |
 
 Required secret mapping (both templates):
@@ -46,7 +57,7 @@ Required secret mapping (both templates):
 
 ## Migration from monolithic `docs-aw.yml`
 
-1. Merge distribution PRs that add `trigger-docs-aw-ai-menu.yml` and `trigger-docs-aw-pr-ai-menu.yml`.
+1. Merge distribution PRs that add `trigger-docs-aw-ai-menu.yml`, `trigger-docs-aw-pr-ai-menu-collect.yml`, and `trigger-docs-aw-pr-ai-menu.yml`.
 2. Delete `.github/workflows/docs-aw.yml` in the consumer repository. Remove legacy `docs-aw-ai-menu.yml` / `docs-aw-pr-ai-menu.yml` client files if present; distribution removes paths no longer in the template tree.
 3. Update Backstage `workflow_ref` / token policies to reference each installed **`trigger-docs-aw-*.yml`** client workflow file.
 

--- a/docs/workflows/docs-aw-pr-ai-menu.md
+++ b/docs/workflows/docs-aw-pr-ai-menu.md
@@ -15,8 +15,8 @@ Reusable implementation for the Docs PR AI menu. The client template `trigger-do
 
 Jobs and routing behavior:
 
-1. `post-menu` posts or refreshes the PR AI menu when the routed event is `pull_request_target` or `workflow_dispatch`.
-2. `evaluate-trigger` runs on routed `issue_comment` events for PRs when an existing AI menu bot comment was edited (`<!-- docs-pr-ai-menu:start -->` and `<!-- docs-pr-ai-menu:end -->` markers).
+1. `post-menu` posts or refreshes the PR AI menu when the routed event is a successful `workflow_run` of [trigger-docs-aw-pr-ai-menu-collect.yml](../../.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-pr-ai-menu-collect.yml) or `workflow_dispatch`. The collect leg uses fork-safe `pull_request`; the privileged leg downloads the PR number artifact and never uses `pull_request_target`.
+2. `evaluate-trigger` runs on routed `issue_comment` events for PRs when an existing AI menu bot comment was edited (`<!-- docs-pr-ai-menu:start -->` and `<!-- docs-pr-ai-menu:end -->` markers). On fork PRs, only organization members may trigger the docs review path.
 3. `run-docs-review` calls `elastic/docs-actions/.github/workflows/gh-aw-docs-review.lock.yml@v1` when `docs_review_triggered == 'true'`, with `review-scope: repo-wide-markdown`.
 4. Refresh jobs update the AI PR menu comment after trigger evaluation and after the downstream review run.
 

--- a/scripts/docs/pr-menu/evaluate-trigger.js
+++ b/scripts/docs/pr-menu/evaluate-trigger.js
@@ -17,7 +17,32 @@
 
 const { parseMenuState } = require('./lib.js');
 
-module.exports = async ({ context, core }) => {
+module.exports = async ({ github, context, core }) => {
+  const { data: pullRequest } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.issue.number,
+  });
+  const baseRepoFullName = `${context.repo.owner}/${context.repo.repo}`;
+  const isForkPR = pullRequest.head.repo.full_name !== baseRepoFullName;
+  if (isForkPR) {
+    let isOrgMember = false;
+    try {
+      const { status } = await github.rest.orgs.checkMembershipForUser({
+        org: context.repo.owner,
+        username: context.actor,
+      });
+      isOrgMember = status === 204;
+    } catch {
+      isOrgMember = false;
+    }
+    if (!isOrgMember) {
+      core.info('Fork PR: skipping docs review for non-org member.');
+      core.setOutput('docs_review_triggered', 'false');
+      return;
+    }
+  }
+
   const body = context.payload.comment.body || '';
   const previousBody = context.payload.changes?.body?.from || '';
 

--- a/scripts/docs/pr-menu/post-menu.js
+++ b/scripts/docs/pr-menu/post-menu.js
@@ -19,13 +19,15 @@ const { upsertMenuComment } = require('./lib.js');
 
 module.exports = async ({ github, context, core }) => {
   const workflowDispatchPrNumber = context.payload.inputs?.pull_request_number;
-  const pullRequestNumber =
+  const envPrNumber = process.env.PULL_REQUEST_NUMBER;
+  const pullRequestNumber = Number(
     context.eventName === 'workflow_dispatch'
-      ? Number(workflowDispatchPrNumber)
-      : context.payload.pull_request.number;
+      ? workflowDispatchPrNumber
+      : envPrNumber || context.payload.pull_request?.number,
+  );
 
-  if (!pullRequestNumber) {
-    core.setFailed('Pull request number is required for workflow_dispatch runs.');
+  if (!pullRequestNumber || Number.isNaN(pullRequestNumber)) {
+    core.setFailed('Pull request number is required.');
     return;
   }
 

--- a/scripts/validate_aw_workflow_prelude.py
+++ b/scripts/validate_aw_workflow_prelude.py
@@ -17,7 +17,8 @@
 """
 Validate that every local *-aw-* workflow under .github/workflows/ calls aw-prelude.yml.
 
-Excludes aw-prelude.yml itself (the shared prelude implementation) and distributed
+Excludes aw-prelude.yml itself (the shared prelude implementation), *-collect.yml
+fork-safe collector reusables (gating runs in the privileged callee), and distributed
 trg-* and trigger-* client entrypoints, which call elastic/oblt-aw reusable workflows remotely.
 """
 
@@ -45,6 +46,7 @@ def list_subject_workflows() -> list[pathlib.Path]:
         for p in paths
         if AW_WORKFLOW_PATTERN.match(p.name)
         and p.name != "aw-prelude.yml"
+        and not p.name.endswith("-collect.yml")
         and not p.name.startswith(("trg-", "trigger-"))
     ]
 


### PR DESCRIPTION
## Summary

Mitigates [SEC-043](https://github.com/elastic/oblt-aw/issues/889) (zizmor `dangerous-triggers` on `pull_request_target`) for the Docs PR AI menu while **keeping fork PR support** and **preserving oblt-aw architecture**: thin distributed client templates, control-plane reusables, and scripts under `scripts/docs/pr-menu/` — not inlined YAML in consumer repos (contrast with the approach in [#896](https://github.com/elastic/oblt-aw/pull/896)).

## Approach: split-workflow (no `pull_request_target`)

### The problem

| Trigger | Fork PR menu posting | SEC-043 risk |
|---------|----------------------|--------------|
| `pull_request` | Token is read-only on external fork PRs — cannot post the menu comment | Low |
| `pull_request_target` | Runs in base-repo context with write-capable `GITHUB_TOKEN` on untrusted fork events | **High** (dangerous trigger) |

We need write access to post/update the AI menu on fork PRs, but must not run privileged work under `pull_request_target`.

### The solution

Use GitHub’s recommended **split-workflow** pattern ([preventing pwn requests](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#preventing-pwn-requests)):

1. **Collect leg (untrusted / fork-safe)** — `trigger-docs-aw-pr-ai-menu-collect.yml` runs on `pull_request` with minimal permissions. It only writes the PR number to an artifact (`pr-number`). No secrets, no menu logic, no write to issues/PRs.
2. **Privileged leg (trusted base-repo context)** — `trigger-docs-aw-pr-ai-menu.yml` runs on `workflow_run` when the collect workflow completes successfully. It calls `docs-aw-pr-ai-menu.yml`, downloads the artifact, and posts the menu with a write-capable token. Untrusted fork code never executes in this context.
3. **Checkbox and manual paths** — `issue_comment` (menu checkbox) and `workflow_dispatch` stay on the main trigger. Fork contributors cannot trigger docs review via the checkbox unless they are org members (`evaluate-trigger.js`).

### Architecture (control plane vs client templates)

```mermaid
flowchart LR
  subgraph client["Consumer repo (distributed templates)"]
    A["trigger-docs-aw-pr-ai-menu-collect.yml<br/>on: pull_request"]
    B["trigger-docs-aw-pr-ai-menu.yml<br/>on: workflow_run, issue_comment, workflow_dispatch"]
  end
  subgraph control["elastic/oblt-aw (control plane)"]
    C["docs-aw-pr-ai-menu-collect.yml"]
    D["docs-aw-pr-ai-menu.yml"]
    E["scripts/docs/pr-menu/*.js"]
  end
  A -->|"workflow_call"| C
  B -->|"workflow_call"| D
  D --> E
  A -->|"pr-number artifact"| B
```

| Layer | Files | Responsibility |
|-------|--------|----------------|
| **Client template** | `trigger-docs-aw-pr-ai-menu-collect.yml` | Events + `uses:` only (~15 lines) |
| **Client template** | `trigger-docs-aw-pr-ai-menu.yml` | Events + `uses:` only; `workflow_run` gated on collect success |
| **Reusable** | `docs-aw-pr-ai-menu-collect.yml` | Upload `pr-number` artifact |
| **Reusable** | `docs-aw-pr-ai-menu.yml` | Prelude gating, download artifact, post menu, evaluate checkbox, run docs review |
| **Scripts** | `scripts/docs/pr-menu/` | Menu comment and trigger logic (single source of truth) |

After merge, re-distribute so consumers install **both** `trigger-docs-aw-pr-ai-menu-collect.yml` and the updated `trigger-docs-aw-pr-ai-menu.yml`, and remove any legacy `pull_request_target` client workflows (e.g. monolithic `docs-aw.yml`).

## Changes in this PR

- Add `trigger-docs-aw-pr-ai-menu-collect.yml` + `docs-aw-pr-ai-menu-collect.yml`
- Replace `pull_request_target` with `workflow_run` on `trigger-docs-aw-pr-ai-menu.yml`
- Extend `docs-aw-pr-ai-menu.yml` to download the collect artifact and resolve the PR number
- Org-membership guard for fork PR checkbox triggers in `evaluate-trigger.js`
- Document split-trigger model in `docs/workflows/docs-aw-client-template.md`

## Test plan

- [ ] Same-repo PR → collect runs, then main workflow posts the AI PR menu comment
- [ ] Fork PR → collect runs (read-only), then main workflow posts the menu on the fork PR
- [ ] `workflow_dispatch` with a PR number → menu refresh still works
- [ ] Fork contributor toggles checkbox → `evaluate-trigger` short-circuits; Elastic org member on fork PR can trigger docs review
- [ ] Security detector no longer emits SEC-043 for docs PR menu client templates

Related issue: 
- https://github.com/elastic/observability-robots/issues/4437
- https://github.com/elastic/oblt-aw/issues/889
Notifies:
- https://github.com/elastic/oblt-aw/pull/896

