### PR TITLE
feat(registry): map control-plane workflows to dashboard ids in registry

### DIFF
--- a/.github/workflows/aw-prelude.yml
+++ b/.github/workflows/aw-prelude.yml
@@ -5,8 +5,11 @@ name: Agentic Workflow Prelude
 on:
   workflow_call:
     inputs:
-      enabled-workflow-id:
-        description: Compound Control Plane id (for example obs:automerge)
+      control-plane-workflow:
+        description: >-
+          Basename of this wrapper under .github/workflows/ (for example
+          oblt-aw-automerge.yml). Compound org:workflow-id is resolved from
+          config/<org>/workflow-registry.json.
         required: true
         type: string
       load-allowed-authors:
@@ -18,7 +21,7 @@ on:
       proceed:
         description: >-
           True when dashboard gating allows this workflow (effective-raw empty or
-          enabled-workflow-id is listed in enabled-workflows).
+          the registry-resolved compound id is listed in enabled-workflows).
         value: ${{ jobs.evaluate.outputs.proceed }}
       effective-raw:
         description: Raw dashboard read before normalization ('' means all enabled)
@@ -74,12 +77,21 @@ jobs:
       allowed-issue-authors-json: ${{ steps.pack.outputs.allowed-issue-authors-json }}
       allowed-issue-authors-csv: ${{ steps.pack.outputs.allowed-issue-authors-csv }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve compound workflow id from registry
+        id: resolve
+        env:
+          CONTROL_PLANE_WORKFLOW: ${{ inputs.control-plane-workflow }}
+        run: python scripts/resolve_control_plane_workflow_id.py "${CONTROL_PLANE_WORKFLOW}"
+
       - name: Evaluate dashboard gate
         id: gate
         env:
           EFFECTIVE_RAW: ${{ needs.dashboard.outputs.effective-raw }}
           ENABLED_WORKFLOWS: ${{ needs.dashboard.outputs.enabled-workflows }}
-          ENABLED_WORKFLOW_ID: ${{ inputs.enabled-workflow-id }}
+          ENABLED_WORKFLOW_ID: ${{ steps.resolve.outputs.compound-workflow-id }}
         run: |
           set -euo pipefail
           if [ -z "${EFFECTIVE_RAW}" ]; then

--- a/.github/workflows/docs-aw-ai-menu.yml
+++ b/.github/workflows/docs-aw-ai-menu.yml
@@ -20,7 +20,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: docs:example-workflow
+      control-plane-workflow: docs-aw-ai-menu.yml
 
   post-menu:
     name: Post or refresh AI menu

--- a/.github/workflows/docs-aw-pr-ai-menu-collect.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu-collect.yml
@@ -11,8 +11,18 @@ permissions:
   contents: read
 
 jobs:
+  prelude:
+    permissions:
+      contents: read
+      issues: read
+    uses: ./.github/workflows/aw-prelude.yml
+    with:
+      control-plane-workflow: docs-aw-pr-ai-menu-collect.yml
+
   collect:
     name: Save PR number artifact
+    needs: prelude
+    if: needs.prelude.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/docs-aw-pr-ai-menu.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu.yml
@@ -20,7 +20,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: docs:example-workflow
+      control-plane-workflow: docs-aw-pr-ai-menu.yml
 
   post-menu:
     name: Post or refresh AI PR menu

--- a/.github/workflows/oblt-aw-agent-suggestions.yml
+++ b/.github/workflows/oblt-aw-agent-suggestions.yml
@@ -15,7 +15,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:agent-suggestions
+      control-plane-workflow: oblt-aw-agent-suggestions.yml
 
   agent-suggestions:
     needs: prelude

--- a/.github/workflows/oblt-aw-autodoc.yml
+++ b/.github/workflows/oblt-aw-autodoc.yml
@@ -15,7 +15,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:autodoc
+      control-plane-workflow: oblt-aw-autodoc.yml
 
   # Step 1: Detect docs drift from recent code changes and create an issue with findings
   audit:

--- a/.github/workflows/oblt-aw-automerge.yml
+++ b/.github/workflows/oblt-aw-automerge.yml
@@ -16,7 +16,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:automerge
+      control-plane-workflow: oblt-aw-automerge.yml
       load-allowed-authors: true
 
   # Single PR from github.event.pull_request. PR fields only (pull_request trigger).

--- a/.github/workflows/oblt-aw-dependency-review.yml
+++ b/.github/workflows/oblt-aw-dependency-review.yml
@@ -15,7 +15,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:dependency-review
+      control-plane-workflow: oblt-aw-dependency-review.yml
       load-allowed-authors: true
 
   dependency-review:

--- a/.github/workflows/oblt-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/oblt-aw-duplicate-issue-detector.yml
@@ -16,7 +16,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:duplicate-issue-detector
+      control-plane-workflow: oblt-aw-duplicate-issue-detector.yml
 
   duplicate-issue-detector:
     needs: prelude

--- a/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
+++ b/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
@@ -18,7 +18,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:estc-pr-buildkite-detective
+      control-plane-workflow: oblt-aw-estc-pr-buildkite-detective.yml
 
   estc-pr-buildkite-detective:
     needs: prelude

--- a/.github/workflows/oblt-aw-issue-fixer.yml
+++ b/.github/workflows/oblt-aw-issue-fixer.yml
@@ -12,7 +12,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:issue-fixer
+      control-plane-workflow: oblt-aw-issue-fixer.yml
 
   run:
     needs: prelude

--- a/.github/workflows/oblt-aw-issue-triage.yml
+++ b/.github/workflows/oblt-aw-issue-triage.yml
@@ -16,7 +16,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:issue-triage
+      control-plane-workflow: oblt-aw-issue-triage.yml
 
   issue-triage:
     needs: prelude

--- a/.github/workflows/oblt-aw-mention-in-issue.yml
+++ b/.github/workflows/oblt-aw-mention-in-issue.yml
@@ -16,7 +16,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:mention-in-issue
+      control-plane-workflow: oblt-aw-mention-in-issue.yml
 
   mention-in-issue:
     needs: prelude

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml
@@ -15,7 +15,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:resource-not-accessible-by-integration
+      control-plane-workflow: oblt-aw-resource-not-accessible-by-integration-detector.yml
 
   discover:
     needs: prelude

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml
@@ -12,7 +12,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:resource-not-accessible-by-integration
+      control-plane-workflow: oblt-aw-resource-not-accessible-by-integration-fixer.yml
       load-allowed-authors: true
 
   res-not-accessible-integration-fixer:

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml
@@ -17,7 +17,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:resource-not-accessible-by-integration
+      control-plane-workflow: oblt-aw-resource-not-accessible-by-integration-triage.yml
       load-allowed-authors: true
 
   res-not-accessible-integration-triage:

--- a/.github/workflows/oblt-aw-security-detector.yml
+++ b/.github/workflows/oblt-aw-security-detector.yml
@@ -13,7 +13,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:security
+      control-plane-workflow: oblt-aw-security-detector.yml
 
   scan:
     needs: prelude

--- a/.github/workflows/oblt-aw-security-fixer.yml
+++ b/.github/workflows/oblt-aw-security-fixer.yml
@@ -15,7 +15,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:security
+      control-plane-workflow: oblt-aw-security-fixer.yml
       load-allowed-authors: true
 
   security-issue-fixer:

--- a/.github/workflows/oblt-aw-security-triage.yml
+++ b/.github/workflows/oblt-aw-security-triage.yml
@@ -16,7 +16,7 @@ jobs:
       issues: read
     uses: ./.github/workflows/aw-prelude.yml
     with:
-      enabled-workflow-id: obs:security
+      control-plane-workflow: oblt-aw-security-triage.yml
       load-allowed-authors: true
 
   security-issue-triage:

--- a/config/docs/workflow-registry.json
+++ b/config/docs/workflow-registry.json
@@ -2,13 +2,23 @@
   "section_title": "Documentation",
   "workflows": [
     {
-      "id": "example-workflow",
-      "name": "Example workflow",
-      "description": "Minimal second-org entry for tests and multi-section dashboard behavior.",
+      "id": "docs-issue-ai-menu",
+      "name": "Docs Issue AI Menu",
+      "description": "Adds a documentation issue AI menu.",
       "maturity": "experimental",
       "default_enabled": false,
       "control_plane_workflows": [
-        "docs-aw-ai-menu.yml",
+        "docs-aw-ai-menu.yml"
+      ]
+    },
+    {
+      "id": "docs-pr-ai-menu",
+      "name": "Docs PR AI Menu",
+      "description": "Adds a documentation PR AI menu.",
+      "maturity": "experimental",
+      "default_enabled": false,
+      "control_plane_workflows": [
+        "docs-aw-pr-ai-menu-collect.yml",
         "docs-aw-pr-ai-menu.yml"
       ]
     }

--- a/config/docs/workflow-registry.json
+++ b/config/docs/workflow-registry.json
@@ -6,7 +6,11 @@
       "name": "Example workflow",
       "description": "Minimal second-org entry for tests and multi-section dashboard behavior.",
       "maturity": "experimental",
-      "default_enabled": false
+      "default_enabled": false,
+      "control_plane_workflows": [
+        "docs-aw-ai-menu.yml",
+        "docs-aw-pr-ai-menu.yml"
+      ]
     }
   ]
 }

--- a/config/obs/workflow-registry.json
+++ b/config/obs/workflow-registry.json
@@ -6,77 +6,96 @@
       "name": "Agent Suggestions",
       "description": "Suggests agentic workflows and improvements for the repository based on analysis of current setup.",
       "maturity": "early-adoption",
-      "default_enabled": true
+      "default_enabled": true,
+      "control_plane_workflows": ["oblt-aw-agent-suggestions.yml"]
     },
     {
       "id": "autodoc",
       "name": "Automated Documentation",
       "description": "Analyzes documentation for gaps, outdated content, and inconsistencies; creates issues and PRs to improve docs.",
       "maturity": "early-adoption",
-      "default_enabled": true
+      "default_enabled": true,
+      "control_plane_workflows": ["oblt-aw-autodoc.yml"]
     },
     {
       "id": "automerge",
       "name": "Automerge",
       "description": "Enables auto-merge for allowed bot PRs (same authors as dependency-review) with oblt-aw/ai/merge-ready when validation and approval gates pass; GitHub enforces required checks at merge time.",
       "maturity": "early-adoption",
-      "default_enabled": true
+      "default_enabled": true,
+      "control_plane_workflows": ["oblt-aw-automerge.yml"]
     },
     {
       "id": "dependency-review",
       "name": "Dependency Review",
       "description": "Analyzes dependency-update PRs from bots, applies merge-ready labels when criteria are met.",
       "maturity": "early-adoption",
-      "default_enabled": true
+      "default_enabled": true,
+      "control_plane_workflows": ["oblt-aw-dependency-review.yml"]
     },
     {
       "id": "duplicate-issue-detector",
       "name": "Duplicate Issue Detector",
       "description": "Detects potential duplicate issues when a new issue is opened or when the entrypoint is run manually.",
       "maturity": "experimental",
-      "default_enabled": false
+      "default_enabled": false,
+      "control_plane_workflows": ["oblt-aw-duplicate-issue-detector.yml"]
     },
     {
       "id": "issue-triage",
       "name": "Issue Triage",
       "description": "Triages newly opened issues using the generic issue-triage agentic workflow.",
       "maturity": "experimental",
-      "default_enabled": false
+      "default_enabled": false,
+      "control_plane_workflows": ["oblt-aw-issue-triage.yml"]
     },
     {
       "id": "issue-fixer",
       "name": "Issue Fixer",
       "description": "Executes generic issue fixes requested with /ai implement comments, excluding specialized security and resource-not-accessible flows.",
       "maturity": "experimental",
-      "default_enabled": false
+      "default_enabled": false,
+      "control_plane_workflows": ["oblt-aw-issue-fixer.yml"]
     },
     {
       "id": "mention-in-issue",
       "name": "Mention in Issue",
       "description": "AI assistant for issues — answers questions, debugs problems, and creates PRs on demand when triggered with a /ai comment.",
       "maturity": "experimental",
-      "default_enabled": false
+      "default_enabled": false,
+      "control_plane_workflows": ["oblt-aw-mention-in-issue.yml"]
     },
     {
       "id": "security",
       "name": "Security",
       "description": "Runs static security checks on workflows, shell scripts, and dependency manifests per the security scanning ruleset; opens issues for findings.",
       "maturity": "experimental",
-      "default_enabled": false
+      "default_enabled": false,
+      "control_plane_workflows": [
+        "oblt-aw-security-detector.yml",
+        "oblt-aw-security-fixer.yml",
+        "oblt-aw-security-triage.yml"
+      ]
     },
     {
       "id": "resource-not-accessible-by-integration",
       "name": "Resource Not Accessible by Integration",
       "description": "Detects 'Resource not accessible by integration' occurrences in workflow logs, creates triage issues, triages newly opened issues, and executes fixes for issues labeled ready to fix.",
       "maturity": "early-adoption",
-      "default_enabled": false
+      "default_enabled": false,
+      "control_plane_workflows": [
+        "oblt-aw-resource-not-accessible-by-integration-detector.yml",
+        "oblt-aw-resource-not-accessible-by-integration-fixer.yml",
+        "oblt-aw-resource-not-accessible-by-integration-triage.yml"
+      ]
     },
     {
       "id": "estc-pr-buildkite-detective",
       "name": "PR Buildkite Detective",
       "description": "Analyzes Buildkite CI failures for a PR when a Buildkite status check fails; posts a diagnostic comment on the pull request.",
       "maturity": "early-adoption",
-      "default_enabled": false
+      "default_enabled": false,
+      "control_plane_workflows": ["oblt-aw-estc-pr-buildkite-detective.yml"]
     }
   ]
 }

--- a/docs/onboarding/adopting-agentic-workflows.md
+++ b/docs/onboarding/adopting-agentic-workflows.md
@@ -24,7 +24,7 @@ Each **organization** owns `config/<org-key>/` (for example `config/obs/`): [`wo
 
 ### 2. Add prelude and route conditions
 
-- First job: `uses: ./.github/workflows/aw-prelude.yml` with `enabled-workflow-id: <org-key>:<workflow-id>` and `load-allowed-authors: true` when PR/issue allow lists apply.
+- First job: `uses: ./.github/workflows/aw-prelude.yml` with `control-plane-workflow: <this-wrapper-basename>.yml` (must appear under that workflow’s `control_plane_workflows` in `workflow-registry.json`) and `load-allowed-authors: true` when PR/issue allow lists apply.
 - Downstream jobs: `needs: prelude` and `if: needs.prelude.outputs.proceed == 'true'` plus event/label/comment guards ([aw-prelude](../workflows/aw-prelude.md)).
 
 ### 3. Mirror permissions from similar workflows
@@ -37,7 +37,7 @@ Each **organization** owns `config/<org-key>/` (for example `config/obs/`): [`wo
 
 ### 5. Register in `workflow-registry.json`
 
-- Add one object with unique `id`, `name`, `description`, `maturity`, and `default_enabled` under `config/<org-key>/workflow-registry.json`.
+- Add one object with unique `id`, `name`, `description`, `maturity`, `default_enabled`, and `control_plane_workflows` (basenames of every `oblt-aw-*` / `docs-aw-*` wrapper that share this dashboard id) under `config/<org-key>/workflow-registry.json`.
 
 ### 6. Add a client template
 
@@ -68,7 +68,7 @@ Each **organization** owns `config/<org-key>/` (for example `config/obs/`): [`wo
 ## Troubleshooting
 
 - **Workflow never runs after checking the box** — Wait for a supported trigger on the installed `trigger-oblt-aw-*.yml` client ([oblt-aw-client-template](../workflows/oblt-aw-client-template.md)).
-- **Validation fails on the PR** — Compare `permissions` with a sibling wrapper; confirm prelude `enabled-workflow-id` matches registry `obs:<id>`.
+- **Validation fails on the PR** — Compare `permissions` with a sibling wrapper; confirm the wrapper basename is listed under the correct `control_plane_workflows` entry in `workflow-registry.json` and prelude passes `control-plane-workflow: <basename>`.
 
 ## References
 

--- a/docs/operations/control-plane-dashboard-format.md
+++ b/docs/operations/control-plane-dashboard-format.md
@@ -22,7 +22,7 @@ There is no config file (no `.github/oblt-aw-config.json`), no PRs when users to
 Every workflow in ingress gating is identified by **`org-key:workflow-id`**:
 
 - **`org-key`** — Directory name under `config/<org-key>/` in `elastic/oblt-aw` (for example `obs`, `docs`). Not to be confused with the repository’s root `docs/` Markdown tree.
-- **`workflow-id`** — Unique within that org’s [`workflow-registry.json`](../../config/obs/workflow-registry.json) (same hyphenated id as today per registry file).
+- **`workflow-id`** — Unique within that org’s [`workflow-registry.json`](../../config/obs/workflow-registry.json). Each registry entry lists every control-plane reusable it gates via `control_plane_workflows` (basenames under `.github/workflows/`, for example `oblt-aw-security-detector.yml`); multiple files may share one `id` (detector/fixer/triage).
 
 **Examples:** `obs:agent-suggestions`, `docs:example-workflow`.
 

--- a/docs/workflows/aw-prelude.md
+++ b/docs/workflows/aw-prelude.md
@@ -14,7 +14,7 @@ Every control-plane `*-aw-*` wrapper (`oblt-aw-*`, `docs-aw-*`) invokes this pre
 
 | Input | Type | Default | Purpose |
 |-------|------|---------|---------|
-| `enabled-workflow-id` | string | (required) | Compound Control Plane id, for example `obs:automerge` |
+| `control-plane-workflow` | string | (required) | Basename of the calling wrapper (for example `oblt-aw-automerge.yml`). Prelude resolves `org:workflow-id` from that org’s [`workflow-registry.json`](../../config/obs/workflow-registry.json) `control_plane_workflows` list. |
 | `load-allowed-authors` | boolean | `false` | When true, loads PR and issue bot allow lists on `pull_request` / `issues` events |
 
 ### Outputs
@@ -32,7 +32,7 @@ Every control-plane `*-aw-*` wrapper (`oblt-aw-*`, `docs-aw-*`) invokes this pre
 Same as ingress historically used:
 
 - `effective-raw` empty → `proceed=true`
-- Otherwise `proceed=true` only when `enabled-workflow-id` is in `enabled-workflows`
+- Otherwise `proceed=true` only when the registry-resolved compound id is in `enabled-workflows`
 
 ## References
 

--- a/docs/workflows/sync-control-plane-dashboard.md
+++ b/docs/workflows/sync-control-plane-dashboard.md
@@ -8,7 +8,7 @@ This workflow creates or updates the **single** Control Plane Dashboard issue in
 
 ## Prerequisites
 
-- Per-org `config/<org-key>/workflow-registry.json` — workflow metadata (`id`, `name`, `description`, `maturity`, `default_enabled`, optional `section_title`)
+- Per-org `config/<org-key>/workflow-registry.json` — workflow metadata (`id`, `name`, `description`, `maturity`, `default_enabled`, `control_plane_workflows`, optional `section_title`)
 - Per-org `config/<org-key>/active-repositories.json` — target repositories for that org’s workflows
 - Token policy configured for [elastic/oblt-actions/github/create-token@v1](https://github.com/elastic/oblt-actions/blob/v1/github/create-token/action.yml)
 - [GitHub CLI (`gh`)](https://cli.github.com/) available in `PATH` (required by `scripts/sync_control_plane_dashboard.py` for `gh api` and issue pinning)

--- a/scripts/resolve_control_plane_workflow_id.py
+++ b/scripts/resolve_control_plane_workflow_id.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright 2026-2027 Elasticsearch B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Resolve a control-plane workflow filename to its compound dashboard id.
+
+Reads config/<org>/workflow-registry.json and writes compound-workflow-id to
+GITHUB_OUTPUT when set, otherwise prints to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from common import write_outputs
+from workflow_registry import resolve_compound_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve control-plane workflow file to org:workflow-id"
+    )
+    parser.add_argument(
+        "control_plane_workflow",
+        help="Workflow basename under .github/workflows/ (for example oblt-aw-automerge.yml)",
+    )
+    parser.add_argument(
+        "--config-dir",
+        type=Path,
+        default=Path("config"),
+        help="Config root containing per-org workflow-registry.json trees",
+    )
+    args = parser.parse_args()
+
+    try:
+        compound_id = resolve_compound_id(args.config_dir, args.control_plane_workflow)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if os.getenv("GITHUB_OUTPUT"):
+        write_outputs({"compound-workflow-id": compound_id})
+    else:
+        print(compound_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_aw_workflow_prelude.py
+++ b/scripts/validate_aw_workflow_prelude.py
@@ -18,8 +18,7 @@
 Validate that every local *-aw-* workflow under .github/workflows/ calls aw-prelude.yml
 and is registered in config/<org>/workflow-registry.json.
 
-Excludes aw-prelude.yml itself (the shared prelude implementation), *-collect.yml
-fork-safe collector reusables (gating runs in the privileged callee), and distributed
+Excludes aw-prelude.yml itself (the shared prelude implementation) and distributed
 trg-* and trigger-* client entrypoints, which call elastic/oblt-aw reusable workflows remotely.
 """
 
@@ -50,7 +49,6 @@ def list_subject_workflows() -> list[pathlib.Path]:
         for p in paths
         if AW_WORKFLOW_PATTERN.match(p.name)
         and p.name != "aw-prelude.yml"
-        and not p.name.endswith("-collect.yml")
         and not p.name.startswith(("trg-", "trigger-"))
     ]
 

--- a/scripts/validate_aw_workflow_prelude.py
+++ b/scripts/validate_aw_workflow_prelude.py
@@ -15,7 +15,8 @@
 # under the License.
 
 """
-Validate that every local *-aw-* workflow under .github/workflows/ calls aw-prelude.yml.
+Validate that every local *-aw-* workflow under .github/workflows/ calls aw-prelude.yml
+and is registered in config/<org>/workflow-registry.json.
 
 Excludes aw-prelude.yml itself (the shared prelude implementation), *-collect.yml
 fork-safe collector reusables (gating runs in the privileged callee), and distributed
@@ -28,7 +29,10 @@ import pathlib
 import re
 import sys
 
+from workflow_registry import validate_registry_against_workflows
+
 WORKFLOWS_DIR = pathlib.Path(".github/workflows")
+CONFIG_DIR = pathlib.Path("config")
 AW_WORKFLOW_PATTERN = re.compile(r".+-aw-.+\.ya?ml$")
 PRELUDE_USES = re.compile(
     r"uses:\s*\./\.github/workflows/aw-prelude\.ya?ml\b",
@@ -73,13 +77,24 @@ def main() -> int:
     for path in subjects:
         errors.extend(validate_workflow(path))
 
+    errors.extend(
+        validate_registry_against_workflows(
+            CONFIG_DIR,
+            WORKFLOWS_DIR,
+            {path.name for path in subjects},
+        )
+    )
+
     if errors:
         print("aw-prelude enforcement failed:", file=sys.stderr)
         for err in errors:
             print(f"  - {err}", file=sys.stderr)
         return 1
 
-    print(f"Validated {len(subjects)} *-aw-* workflow(s) call aw-prelude.yml.")
+    print(
+        f"Validated {len(subjects)} *-aw-* workflow(s) call aw-prelude.yml "
+        "and match workflow-registry.json."
+    )
     return 0
 
 

--- a/scripts/workflow_registry.py
+++ b/scripts/workflow_registry.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Copyright 2026-2027 Elasticsearch B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Load and validate per-org workflow-registry.json files.
+
+Each workflow entry maps a dashboard ``id`` to one or more control-plane reusable
+workflow files under ``.github/workflows/`` via ``control_plane_workflows``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from common import compound_workflow_key, discover_org_config_dirs
+
+CONTROL_PLANE_WORKFLOW_NAME = re.compile(r"^[a-z0-9-]+-aw-[a-z0-9-]+\.ya?ml$")
+PRELUDE_CONTROL_PLANE_WORKFLOW = re.compile(
+    r"control-plane-workflow:\s*([^\s#]+)",
+    re.MULTILINE,
+)
+LEGACY_ENABLED_WORKFLOW_ID = re.compile(
+    r"enabled-workflow-id:\s*([^\s#]+)",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class RegistryWorkflowEntry:
+    org_key: str
+    workflow_id: str
+    control_plane_workflows: tuple[str, ...]
+
+    @property
+    def compound_id(self) -> str:
+        return compound_workflow_key(self.org_key, self.workflow_id)
+
+
+def load_workflow_registry(org_dir: Path) -> dict[str, object]:
+    path = org_dir / "workflow-registry.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{org_dir}: workflow-registry.json must be a JSON object")
+    return data
+
+
+def parse_registry_entries(org_dir: Path) -> list[RegistryWorkflowEntry]:
+    raw = load_workflow_registry(org_dir)
+    workflows = raw.get("workflows")
+    if not isinstance(workflows, list):
+        raise ValueError(
+            f"{org_dir}: workflow-registry.json must contain a workflows array"
+        )
+
+    org_key = org_dir.name
+    entries: list[RegistryWorkflowEntry] = []
+    for index, item in enumerate(workflows):
+        if not isinstance(item, dict):
+            raise ValueError(f"{org_dir}: workflows[{index}] must be an object")
+        workflow_id = item.get("id")
+        if not isinstance(workflow_id, str) or not workflow_id:
+            raise ValueError(
+                f"{org_dir}: workflows[{index}].id must be a non-empty string"
+            )
+
+        files = item.get("control_plane_workflows")
+        if not isinstance(files, list) or not files:
+            raise ValueError(
+                f"{org_dir}: workflows[{index}] ({workflow_id!r}) must define a "
+                "non-empty control_plane_workflows array"
+            )
+        normalized: list[str] = []
+        for file_index, name in enumerate(files):
+            if not isinstance(name, str) or not CONTROL_PLANE_WORKFLOW_NAME.match(name):
+                raise ValueError(
+                    f"{org_dir}: workflows[{index}].control_plane_workflows[{file_index}] "
+                    f"must match *-aw-*.yml, got {name!r}"
+                )
+            normalized.append(name)
+        entries.append(
+            RegistryWorkflowEntry(
+                org_key=org_key,
+                workflow_id=workflow_id,
+                control_plane_workflows=tuple(normalized),
+            )
+        )
+    return entries
+
+
+def build_control_plane_workflow_index(
+    config_dir: Path,
+) -> dict[str, RegistryWorkflowEntry]:
+    """Map control-plane workflow basename -> registry entry (globally unique)."""
+    index: dict[str, RegistryWorkflowEntry] = {}
+    for org_dir in discover_org_config_dirs(config_dir):
+        for entry in parse_registry_entries(org_dir):
+            for filename in entry.control_plane_workflows:
+                if filename in index:
+                    previous = index[filename]
+                    raise ValueError(
+                        f"control_plane_workflows[{filename!r}] is listed under both "
+                        f"{previous.org_key}:{previous.workflow_id} and "
+                        f"{entry.org_key}:{entry.workflow_id}"
+                    )
+                index[filename] = entry
+    return index
+
+
+def resolve_compound_id(config_dir: Path, control_plane_workflow: str) -> str:
+    index = build_control_plane_workflow_index(config_dir)
+    entry = index.get(control_plane_workflow)
+    if entry is None:
+        known = ", ".join(sorted(index))
+        raise ValueError(
+            f"control-plane workflow {control_plane_workflow!r} is not listed in any "
+            f"workflow-registry.json control_plane_workflows (known: {known})"
+        )
+    return entry.compound_id
+
+
+def validate_registry_against_workflows(
+    config_dir: Path,
+    workflows_dir: Path,
+    subject_workflow_names: set[str],
+) -> list[str]:
+    """Return human-readable validation errors (empty when valid)."""
+    errors: list[str] = []
+    try:
+        index = build_control_plane_workflow_index(config_dir)
+    except ValueError as exc:
+        return [str(exc)]
+
+    registered = set(index)
+    missing = subject_workflow_names - registered
+    if missing:
+        for name in sorted(missing):
+            errors.append(
+                f"{workflows_dir / name}: not listed in any "
+                "workflow-registry.json control_plane_workflows"
+            )
+
+    stale = registered - subject_workflow_names
+    for name in sorted(stale):
+        entry = index[name]
+        errors.append(
+            f"workflow-registry.json ({entry.org_key}:{entry.workflow_id}) lists "
+            f"{name!r} but no matching file exists under {workflows_dir}"
+        )
+
+    for path_name in subject_workflow_names:
+        path = workflows_dir / path_name
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        if LEGACY_ENABLED_WORKFLOW_ID.search(text):
+            errors.append(
+                f"{path}: use control-plane-workflow instead of enabled-workflow-id "
+                "(compound id is resolved from workflow-registry.json)"
+            )
+            continue
+        match = PRELUDE_CONTROL_PLANE_WORKFLOW.search(text)
+        if not match:
+            errors.append(
+                f"{path}: prelude must pass control-plane-workflow matching this file"
+            )
+            continue
+        declared = match.group(1)
+        if declared != path_name:
+            errors.append(
+                f"{path}: control-plane-workflow is {declared!r}, expected {path_name!r}"
+            )
+            continue
+    return errors

--- a/tests/test_validate_aw_workflow_prelude.py
+++ b/tests/test_validate_aw_workflow_prelude.py
@@ -44,7 +44,8 @@ def test_validate_workflow_accepts_prelude_job(
     good = workflows / "oblt-aw-test.yml"
     good.write_text(
         "name: Test\non:\n  workflow_call:\njobs:\n"
-        "  prelude:\n    uses: ./.github/workflows/aw-prelude.yml\n",
+        "  prelude:\n    uses: ./.github/workflows/aw-prelude.yml\n"
+        "    with:\n      control-plane-workflow: oblt-aw-test.yml\n",
         encoding="utf-8",
     )
     monkeypatch.setattr(validator, "WORKFLOWS_DIR", workflows)

--- a/tests/test_validate_aw_workflow_prelude.py
+++ b/tests/test_validate_aw_workflow_prelude.py
@@ -16,6 +16,7 @@ def test_list_subject_workflows_includes_oblt_aw_wrappers() -> None:
     names = {p.name for p in validator.list_subject_workflows()}
     assert "oblt-aw-automerge.yml" in names
     assert "docs-aw-ai-menu.yml" in names
+    assert "docs-aw-pr-ai-menu-collect.yml" in names
     assert "docs-aw-pr-ai-menu.yml" in names
     assert "aw-prelude.yml" not in names
     assert "trg-oblt-aw-automerge.yml" not in names

--- a/tests/test_workflow_registry.py
+++ b/tests/test_workflow_registry.py
@@ -1,0 +1,94 @@
+"""Tests for scripts/workflow_registry.py."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "scripts"))
+
+import workflow_registry as wr  # noqa: E402
+
+
+def _write_org(
+    config_dir: pathlib.Path,
+    org_key: str,
+    workflows: list[dict],
+    repos: list[str] | None = None,
+) -> None:
+    org_dir = config_dir / org_key
+    org_dir.mkdir(parents=True)
+    (org_dir / "workflow-registry.json").write_text(
+        json.dumps({"workflows": workflows}),
+        encoding="utf-8",
+    )
+    (org_dir / "active-repositories.json").write_text(
+        json.dumps({"repositories": repos or []}),
+        encoding="utf-8",
+    )
+
+
+class TestResolveCompoundId:
+    def test_single_file_entry(self, tmp_path: pathlib.Path) -> None:
+        _write_org(
+            tmp_path,
+            "obs",
+            [
+                {
+                    "id": "automerge",
+                    "control_plane_workflows": ["oblt-aw-automerge.yml"],
+                }
+            ],
+        )
+        assert (
+            wr.resolve_compound_id(tmp_path, "oblt-aw-automerge.yml") == "obs:automerge"
+        )
+
+    def test_multi_file_entry(self, tmp_path: pathlib.Path) -> None:
+        _write_org(
+            tmp_path,
+            "obs",
+            [
+                {
+                    "id": "security",
+                    "control_plane_workflows": [
+                        "oblt-aw-security-detector.yml",
+                        "oblt-aw-security-fixer.yml",
+                    ],
+                }
+            ],
+        )
+        assert (
+            wr.resolve_compound_id(tmp_path, "oblt-aw-security-fixer.yml")
+            == "obs:security"
+        )
+
+    def test_unknown_file_raises(self, tmp_path: pathlib.Path) -> None:
+        _write_org(
+            tmp_path,
+            "obs",
+            [{"id": "automerge", "control_plane_workflows": ["oblt-aw-automerge.yml"]}],
+        )
+        with pytest.raises(ValueError, match="not listed"):
+            wr.resolve_compound_id(tmp_path, "oblt-aw-missing.yml")
+
+
+class TestValidateRegistryAgainstWorkflows:
+    def test_flags_missing_registry_entry(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_org(
+            tmp_path,
+            "obs",
+            [{"id": "automerge", "control_plane_workflows": ["oblt-aw-automerge.yml"]}],
+        )
+        workflows = tmp_path / "workflows"
+        workflows.mkdir()
+        (workflows / "oblt-aw-agent-suggestions.yml").write_text("", encoding="utf-8")
+        errors = wr.validate_registry_against_workflows(
+            tmp_path, workflows, {"oblt-aw-agent-suggestions.yml"}
+        )
+        assert any("not listed" in err for err in errors)


### PR DESCRIPTION
## Summary
- Add `control_plane_workflows` to each `workflow-registry.json` entry so dashboard `id` → reusable workflow files is explicit (including multi-file ids like `security` and `resource-not-accessible-by-integration`).
- Replace prelude `enabled-workflow-id` with `control-plane-workflow` (wrapper basename); prelude resolves `org:workflow-id` from the registry at runtime.
- Extend CI validation so every `*-aw-*` wrapper is registered and passes the correct basename.

## Test plan
- [x] `python3 scripts/validate_aw_workflow_prelude.py`
- [x] `pytest tests/` (107 passed)

## Risks / Known Gaps
- Prelude `evaluate` job now checks out the repo to read registry JSON (small added latency).

Related issue: https://github.com/elastic/observability-robots/issues/4561
