### PR TITLE
fix(prelude): checkout elastic/oblt-aw for registry scripts in evaluate job

### DIFF
--- a/.github/workflows/aw-prelude.yml
+++ b/.github/workflows/aw-prelude.yml
@@ -77,14 +77,26 @@ jobs:
       allowed-issue-authors-json: ${{ steps.pack.outputs.allowed-issue-authors-json }}
       allowed-issue-authors-csv: ${{ steps.pack.outputs.allowed-issue-authors-csv }}
     steps:
-      - name: Checkout
+      - name: Checkout oblt-aw (registry scripts + config)
         uses: actions/checkout@v6
+        with:
+          repository: elastic/oblt-aw
+          ref: main
+          path: _oblt-aw
+          fetch-depth: 1
+          token: ${{ github.token }}
+          sparse-checkout: |
+            scripts/resolve_control_plane_workflow_id.py
+            scripts/workflow_registry.py
+            scripts/common.py
+            config/
+          sparse-checkout-cone-mode: false
 
       - name: Resolve compound workflow id from registry
         id: resolve
         env:
           CONTROL_PLANE_WORKFLOW: ${{ inputs.control-plane-workflow }}
-        run: python scripts/resolve_control_plane_workflow_id.py "${CONTROL_PLANE_WORKFLOW}"
+        run: python _oblt-aw/scripts/resolve_control_plane_workflow_id.py "${CONTROL_PLANE_WORKFLOW}" --config-dir _oblt-aw/config
 
       - name: Evaluate dashboard gate
         id: gate


### PR DESCRIPTION
## Summary

- The `evaluate` job in `aw-prelude.yml` was running `actions/checkout@v6` with no `repository:` override, so it checked out the **calling** repository (`github.repository`). In a reusable-workflow context that is always the consumer repo, not `elastic/oblt-aw`.
- The next step then tried to run `scripts/resolve_control_plane_workflow_id.py` — a script that only exists in `elastic/oblt-aw` — causing every consumer repo to fail with `No such file or directory` (first observed: [elastic/opentelemetry run 26576801701](https://github.com/elastic/opentelemetry/actions/runs/26576801701/job/78298266629)).
- Fix: replace the plain checkout with a sparse checkout of `elastic/oblt-aw` at `_oblt-aw/` (the three scripts + `config/`), then pass `--config-dir _oblt-aw/config` to the script. This mirrors the pattern already used by `get-enabled-workflows.yml`.

## Test plan

- [ ] Trigger any agentic workflow in a consumer repo (e.g. `elastic/opentelemetry`) and confirm the `prelude / evaluate` job reaches `Evaluate dashboard gate` without error
- [ ] Confirm `proceed` output is correct (true when no dashboard, or when the compound id is in enabled-workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)