### PR TITLE
fix(docs): replace script-path with inline script require in docs AI menu workflows

### DIFF
--- a/.github/workflows/docs-aw-ai-menu.yml
+++ b/.github/workflows/docs-aw-ai-menu.yml
@@ -52,7 +52,9 @@ jobs:
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script-path: oblt-aw-scripts/scripts/docs/issue-menu/post-menu.js
+          script: |
+            const fn = require('./oblt-aw-scripts/scripts/docs/issue-menu/post-menu.js')
+            await fn({github, context, core})
 
   evaluate-trigger:
     name: Evaluate AI menu trigger
@@ -89,7 +91,9 @@ jobs:
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script-path: oblt-aw-scripts/scripts/docs/issue-menu/evaluate-trigger.js
+          script: |
+            const fn = require('./oblt-aw-scripts/scripts/docs/issue-menu/evaluate-trigger.js')
+            await fn({github, context, core})
 
   refresh-menu-after-trigger:
     name: Refresh AI menu after trigger
@@ -124,7 +128,9 @@ jobs:
           ISSUE_SCOPE_TRIGGERED: ${{ needs.evaluate-trigger.outputs.issue_scope_triggered }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script-path: oblt-aw-scripts/scripts/docs/issue-menu/refresh-after-trigger.js
+          script: |
+            const fn = require('./oblt-aw-scripts/scripts/docs/issue-menu/refresh-after-trigger.js')
+            await fn({github, context, core})
 
   run-docs-triage:
     name: Docs AI / triage
@@ -183,7 +189,9 @@ jobs:
           TRIAGE_RESULT: ${{ needs.run-docs-triage.result }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script-path: oblt-aw-scripts/scripts/docs/issue-menu/refresh-after-docs-triage.js
+          script: |
+            const fn = require('./oblt-aw-scripts/scripts/docs/issue-menu/refresh-after-docs-triage.js')
+            await fn({github, context, core})
 
   refresh-menu-after-docs-issue-scope:
     name: Refresh AI menu after docs issue scope
@@ -215,4 +223,6 @@ jobs:
           ISSUE_SCOPE_RESULT: ${{ needs.run-docs-issue-scope.result }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script-path: oblt-aw-scripts/scripts/docs/issue-menu/refresh-after-docs-issue-scope.js
+          script: |
+            const fn = require('./oblt-aw-scripts/scripts/docs/issue-menu/refresh-after-docs-issue-scope.js')
+            await fn({github, context, core})

--- a/.github/workflows/docs-aw-pr-ai-menu.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu.yml
@@ -79,7 +79,9 @@ jobs:
           PULL_REQUEST_NUMBER: ${{ steps.resolve-pr.outputs.number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script-path: oblt-aw-scripts/scripts/docs/pr-menu/post-menu.js
+          script: |
+            const fn = require('./oblt-aw-scripts/scripts/docs/pr-menu/post-menu.js')
+            await fn({github, context, core})
 
   evaluate-trigger:
     name: Evaluate AI PR menu trigger
@@ -116,7 +118,9 @@ jobs:
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script-path: oblt-aw-scripts/scripts/docs/pr-menu/evaluate-trigger.js
+          script: |
+            const fn = require('./oblt-aw-scripts/scripts/docs/pr-menu/evaluate-trigger.js')
+            await fn({github, context, core})
 
   refresh-menu-after-trigger:
     name: Refresh AI PR menu after trigger
@@ -148,7 +152,9 @@ jobs:
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script-path: oblt-aw-scripts/scripts/docs/pr-menu/refresh-after-trigger.js
+          script: |
+            const fn = require('./oblt-aw-scripts/scripts/docs/pr-menu/refresh-after-trigger.js')
+            await fn({github, context, core})
 
   run-docs-review:
     name: Docs AI / docs review
@@ -200,4 +206,6 @@ jobs:
           DOCS_REVIEW_RESULT: ${{ needs.run-docs-review.result }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script-path: oblt-aw-scripts/scripts/docs/pr-menu/refresh-after-docs-review.js
+          script: |
+            const fn = require('./oblt-aw-scripts/scripts/docs/pr-menu/refresh-after-docs-review.js')
+            await fn({github, context, core})


### PR DESCRIPTION
## Summary

- `actions/github-script@v9` does not support the `script-path` input — it silently ignores it, then fails with `Input required and not supplied: script`
- Replaces all 9 `script-path:` usages across `docs-aw-ai-menu.yml` (5 steps) and `docs-aw-pr-ai-menu.yml` (4 steps) with an inline `script:` that `require()`s the file and calls it
- Fixes the failure visible in [elastic/opentelemetry run #26585218648](https://github.com/elastic/opentelemetry/actions/runs/26585218648)

## Test plan

- [ ] Trigger the docs AI issue menu workflow in a consumer repo and confirm the "Post or refresh AI menu" step succeeds
- [ ] Trigger the docs AI PR menu workflow and confirm the "Create or update AI PR menu comment" step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)