### PR TITLE
fix(docs): remove prelude from collect workflow to fix pull_request startup_failure

### DIFF
--- a/.github/workflows/docs-aw-pr-ai-menu-collect.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu-collect.yml
@@ -11,18 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  prelude:
-    permissions:
-      contents: read
-      issues: read
-    uses: ./.github/workflows/aw-prelude.yml
-    with:
-      control-plane-workflow: docs-aw-pr-ai-menu-collect.yml
-
   collect:
     name: Save PR number artifact
-    needs: prelude
-    if: needs.prelude.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Summary

- PR #1086 added a `prelude` job to `docs-aw-pr-ai-menu-collect.yml`, creating a 4-level nested reusable workflow chain on `pull_request` events: `trigger → docs-aw-pr-ai-menu-collect.yml → aw-prelude.yml → get-enabled-workflows.yml`. GitHub fails with `startup_failure` at exactly this depth for `pull_request` triggers (first observed: [elastic/opentelemetry run 26574684350](https://github.com/elastic/opentelemetry/actions/runs/26574684350), 4 minutes after #1086 merged; still failing after #1089 and #1090).
- The collect workflow is the thin fork-safe leg of the split-workflow pattern — its only job is to save the PR number artifact. Dashboard gating is already enforced by the second leg (`docs-aw-pr-ai-menu.yml`), which has its own `prelude` job and only fires when the collect `workflow_run` concludes `success`. Gating in the collect step is redundant and causes the nesting depth issue.
- Fix: remove the `prelude` job and its `needs` / `if` conditions from `docs-aw-pr-ai-menu-collect.yml`, reducing the chain to 2 levels.

## Test plan

- [ ] Open a pull request in `elastic/opentelemetry` and confirm "Docs Agentic Workflow — AI PR Menu (collect)" completes with `success` (not `startup_failure`)
- [ ] Confirm the downstream "Docs Agentic Workflow — AI PR Menu" run is triggered and gates correctly via its own `prelude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)