### PR TITLE
fix(docs): add issues:read to collect trigger for dashboard gating

### DIFF
--- a/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-ai-menu.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 jobs:
   run-aw:

--- a/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-pr-ai-menu-collect.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-pr-ai-menu-collect.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 jobs:
   collect:

--- a/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-pr-ai-menu.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-pr-ai-menu.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 jobs:
   run-aw:


### PR DESCRIPTION
## Summary

- PR #1086 added a `prelude` job to `docs-aw-pr-ai-menu-collect.yml` that calls `aw-prelude` → `get-enabled-workflows`, which reads the `oblt-aw/dashboard` issue.
- The distributed client template `trigger-docs-aw-pr-ai-menu-collect.yml` only declared `contents: read` at the top level. GitHub validates the token's permissions against the full reusable workflow chain at startup on `pull_request` events, and rejected it because `issues: read` was missing — causing `startup_failure` (e.g. [elastic/opentelemetry run 26625355205](https://github.com/elastic/opentelemetry/actions/runs/26625355205)).
- Fix: add `issues: read` to the top-level `permissions` block in the template. The distribute workflow will propagate this to all consumer repos.

## Test plan

- [ ] Trigger a pull request in `elastic/opentelemetry` and confirm "Docs Agentic Workflow — AI PR Menu (collect)" completes with `success`

🤖 Generated with [Claude Code](https://claude.com/claude-code)