### PR TITLE
chore: remove oblt test env from active repos

### DIFF
--- a/config/obs/active-repositories.json
+++ b/config/obs/active-repositories.json
@@ -10,7 +10,6 @@
         "elastic/observability-catalog",
         "elastic/observability-github-secrets",
         "elastic/observability-github-settings",
-        "elastic/observability-robots",
-        "elastic/observability-test-environments"
+        "elastic/observability-robots"
     ]
 }


### PR DESCRIPTION
This pull request makes a small update to the `active-repositories.json` configuration file, removing `elastic/observability-test-environments` from the list of active repositories.