### PR TITLE
fix(workflows): read relayed ingress event in github-script follow-ups

### DIFF
--- a/.github/workflows/docs-aw-ai-menu.yml
+++ b/.github/workflows/docs-aw-ai-menu.yml
@@ -18,9 +18,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from docs-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
     secrets:
       COPILOT_GITHUB_TOKEN:
         required: false
@@ -46,7 +45,7 @@ jobs:
       contents: read
       issues: write
     concurrency:
-      group: docs-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).issue.number || fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).inputs.issue_number }}
+      group: docs-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json).issue.number || fromJSON(inputs.ingress-event-payload-json).inputs.issue_number }}
       cancel-in-progress: false
     steps:
       - name: Checkout oblt-aw for Docs AI issue menu scripts
@@ -57,11 +56,14 @@ jobs:
           path: oblt-aw-scripts
           fetch-depth: 1
           sparse-checkout: |
+            scripts/docs/lib
             scripts/docs/issue-menu
           sparse-checkout-cone-mode: true
 
       - name: Create or update AI menu comment
         uses: actions/github-script@v9
+        env:
+          INGRESS_EVENT_JSON: ${{ inputs.ingress-event-payload-json }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -75,11 +77,11 @@ jobs:
         inputs.ingress-event-name != '' && inputs.ingress-event-name ||
         github.event_name
       ) == 'issue_comment' &&
-      fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).issue.pull_request == null &&
+      fromJSON(inputs.ingress-event-payload-json).issue.pull_request == null &&
       github.actor != 'github-actions[bot]' &&
-      fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).comment.user.login == 'github-actions[bot]' &&
-      contains(fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).comment.body, '<!-- docs-ai-menu:start -->') &&
-      contains(fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).comment.body, '<!-- docs-ai-menu:end -->')
+      fromJSON(inputs.ingress-event-payload-json).comment.user.login == 'github-actions[bot]' &&
+      contains(fromJSON(inputs.ingress-event-payload-json).comment.body, '<!-- docs-ai-menu:start -->') &&
+      contains(fromJSON(inputs.ingress-event-payload-json).comment.body, '<!-- docs-ai-menu:end -->')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -96,12 +98,15 @@ jobs:
           path: oblt-aw-scripts
           fetch-depth: 1
           sparse-checkout: |
+            scripts/docs/lib
             scripts/docs/issue-menu
           sparse-checkout-cone-mode: true
 
       - name: Parse AI menu transition
         id: evaluate
         uses: actions/github-script@v9
+        env:
+          INGRESS_EVENT_JSON: ${{ inputs.ingress-event-payload-json }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -120,7 +125,7 @@ jobs:
       contents: read
       issues: write
     concurrency:
-      group: docs-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).issue.number || fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).inputs.issue_number }}
+      group: docs-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json).issue.number || fromJSON(inputs.ingress-event-payload-json).inputs.issue_number }}
       cancel-in-progress: false
     steps:
       - name: Checkout oblt-aw for Docs AI issue menu scripts
@@ -131,12 +136,14 @@ jobs:
           path: oblt-aw-scripts
           fetch-depth: 1
           sparse-checkout: |
+            scripts/docs/lib
             scripts/docs/issue-menu
           sparse-checkout-cone-mode: true
 
       - name: Refresh AI menu status
         uses: actions/github-script@v9
         env:
+          INGRESS_EVENT_JSON: ${{ inputs.ingress-event-payload-json }}
           TRIAGE_TRIGGERED: ${{ needs.evaluate-trigger.outputs.triage_triggered }}
           ISSUE_SCOPE_TRIGGERED: ${{ needs.evaluate-trigger.outputs.issue_scope_triggered }}
         with:
@@ -206,7 +213,7 @@ jobs:
       contents: read
       issues: write
     concurrency:
-      group: docs-ai-menu-${{ github.event.issue.number || github.event.inputs.issue_number }}
+      group: docs-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json).issue.number || fromJSON(inputs.ingress-event-payload-json).inputs.issue_number }}
       cancel-in-progress: false
     steps:
       - name: Checkout oblt-aw for Docs AI issue menu scripts
@@ -217,12 +224,14 @@ jobs:
           path: oblt-aw-scripts
           fetch-depth: 1
           sparse-checkout: |
+            scripts/docs/lib
             scripts/docs/issue-menu
           sparse-checkout-cone-mode: true
 
       - name: Refresh AI menu status
         uses: actions/github-script@v9
         env:
+          INGRESS_EVENT_JSON: ${{ inputs.ingress-event-payload-json }}
           TRIAGE_RESULT: ${{ needs.run-docs-triage.result }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -240,7 +249,7 @@ jobs:
       contents: read
       issues: write
     concurrency:
-      group: docs-ai-menu-${{ github.event.issue.number || github.event.inputs.issue_number }}
+      group: docs-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json).issue.number || fromJSON(inputs.ingress-event-payload-json).inputs.issue_number }}
       cancel-in-progress: false
     steps:
       - name: Checkout oblt-aw for Docs AI issue menu scripts
@@ -251,12 +260,14 @@ jobs:
           path: oblt-aw-scripts
           fetch-depth: 1
           sparse-checkout: |
+            scripts/docs/lib
             scripts/docs/issue-menu
           sparse-checkout-cone-mode: true
 
       - name: Refresh AI menu status
         uses: actions/github-script@v9
         env:
+          INGRESS_EVENT_JSON: ${{ inputs.ingress-event-payload-json }}
           ISSUE_SCOPE_RESULT: ${{ needs.run-docs-issue-scope.result }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-aw-pr-ai-menu-collect.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu-collect.yml
@@ -18,9 +18,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from docs-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
 
 permissions:
   contents: read
@@ -36,7 +35,7 @@ jobs:
     steps:
       - name: Write pull request number
         env:
-          PR_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request.number }}
+          PR_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}
         run: echo "$PR_NUMBER" > pr_number.txt
 
       - name: Upload pull request number artifact

--- a/.github/workflows/docs-aw-pr-ai-menu.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu.yml
@@ -18,9 +18,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from docs-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
     secrets:
       COPILOT_GITHUB_TOKEN:
         required: false
@@ -37,7 +36,7 @@ jobs:
           inputs.ingress-event-name != '' && inputs.ingress-event-name ||
           github.event_name
         ) == 'workflow_run' &&
-        fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).workflow_run.conclusion == 'success'
+        fromJSON(inputs.ingress-event-payload-json).workflow_run.conclusion == 'success'
       ) ||
       (
         inputs.ingress-event-name != '' && inputs.ingress-event-name ||
@@ -52,7 +51,7 @@ jobs:
       issues: write
       pull-requests: write
     concurrency:
-      group: docs-pr-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).workflow_run.id || fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request.number || fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).issue.number || fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).inputs.pull_request_number }}
+      group: docs-pr-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json).workflow_run.id || fromJSON(inputs.ingress-event-payload-json).pull_request.number || fromJSON(inputs.ingress-event-payload-json).issue.number || fromJSON(inputs.ingress-event-payload-json).inputs.pull_request_number }}
       cancel-in-progress: false
     steps:
       - name: Download pull request number artifact
@@ -64,14 +63,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: pr-number
-          run-id: ${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).workflow_run.id }}
+          run-id: ${{ fromJSON(inputs.ingress-event-payload-json).workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve pull request number
         id: resolve-pr
         env:
           EVENT_NAME: ${{ inputs.ingress-event-name != '' && inputs.ingress-event-name || github.event_name }}
-          WORKFLOW_DISPATCH_PR: ${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).inputs.pull_request_number }}
+          WORKFLOW_DISPATCH_PR: ${{ fromJSON(inputs.ingress-event-payload-json).inputs.pull_request_number }}
         run: |
           if [ "${EVENT_NAME}" = "workflow_run" ]; then
             echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
@@ -87,12 +86,14 @@ jobs:
           path: oblt-aw-scripts
           fetch-depth: 1
           sparse-checkout: |
+            scripts/docs/lib
             scripts/docs/pr-menu
           sparse-checkout-cone-mode: true
 
       - name: Create or update AI PR menu comment
         uses: actions/github-script@v9
         env:
+          INGRESS_EVENT_JSON: ${{ inputs.ingress-event-payload-json }}
           PULL_REQUEST_NUMBER: ${{ steps.resolve-pr.outputs.number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -107,11 +108,11 @@ jobs:
         inputs.ingress-event-name != '' && inputs.ingress-event-name ||
         github.event_name
       ) == 'issue_comment' &&
-      fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).issue.pull_request != null &&
+      fromJSON(inputs.ingress-event-payload-json).issue.pull_request != null &&
       github.actor != 'github-actions[bot]' &&
-      fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).comment.user.login == 'github-actions[bot]' &&
-      contains(fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).comment.body, '<!-- docs-pr-ai-menu:start -->') &&
-      contains(fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).comment.body, '<!-- docs-pr-ai-menu:end -->')
+      fromJSON(inputs.ingress-event-payload-json).comment.user.login == 'github-actions[bot]' &&
+      contains(fromJSON(inputs.ingress-event-payload-json).comment.body, '<!-- docs-pr-ai-menu:start -->') &&
+      contains(fromJSON(inputs.ingress-event-payload-json).comment.body, '<!-- docs-pr-ai-menu:end -->')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -128,12 +129,15 @@ jobs:
           path: oblt-aw-scripts
           fetch-depth: 1
           sparse-checkout: |
+            scripts/docs/lib
             scripts/docs/pr-menu
           sparse-checkout-cone-mode: true
 
       - name: Parse AI PR menu transition
         id: evaluate
         uses: actions/github-script@v9
+        env:
+          INGRESS_EVENT_JSON: ${{ inputs.ingress-event-payload-json }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -152,7 +156,7 @@ jobs:
       issues: write
       pull-requests: write
     concurrency:
-      group: docs-pr-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request.number || fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).issue.number || fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).inputs.pull_request_number }}
+      group: docs-pr-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number || fromJSON(inputs.ingress-event-payload-json).issue.number || fromJSON(inputs.ingress-event-payload-json).inputs.pull_request_number }}
       cancel-in-progress: false
     steps:
       - name: Checkout oblt-aw for Docs PR AI menu scripts
@@ -163,11 +167,14 @@ jobs:
           path: oblt-aw-scripts
           fetch-depth: 1
           sparse-checkout: |
+            scripts/docs/lib
             scripts/docs/pr-menu
           sparse-checkout-cone-mode: true
 
       - name: Refresh AI PR menu status
         uses: actions/github-script@v9
+        env:
+          INGRESS_EVENT_JSON: ${{ inputs.ingress-event-payload-json }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -214,7 +221,7 @@ jobs:
       issues: write
       pull-requests: write
     concurrency:
-      group: docs-pr-ai-menu-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pull_request_number }}
+      group: docs-pr-ai-menu-${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number || fromJSON(inputs.ingress-event-payload-json).issue.number || fromJSON(inputs.ingress-event-payload-json).inputs.pull_request_number }}
       cancel-in-progress: false
     steps:
       - name: Checkout oblt-aw for Docs PR AI menu scripts
@@ -225,12 +232,14 @@ jobs:
           path: oblt-aw-scripts
           fetch-depth: 1
           sparse-checkout: |
+            scripts/docs/lib
             scripts/docs/pr-menu
           sparse-checkout-cone-mode: true
 
       - name: Refresh AI PR menu status
         uses: actions/github-script@v9
         env:
+          INGRESS_EVENT_JSON: ${{ inputs.ingress-event-payload-json }}
           DOCS_REVIEW_RESULT: ${{ needs.run-docs-review.result }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/oblt-aw-agent-suggestions.yml
+++ b/.github/workflows/oblt-aw-agent-suggestions.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-autodoc.yml
+++ b/.github/workflows/oblt-aw-autodoc.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-automerge.yml
+++ b/.github/workflows/oblt-aw-automerge.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false
@@ -37,7 +36,7 @@ permissions:
 
 jobs:
 
-  # Single PR from fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request. PR fields only (pull_request trigger).
+  # Single PR from fromJSON(inputs.ingress-event-payload-json).pull_request (relayed consumer event).
   verify:
     runs-on: ubuntu-latest
     permissions:
@@ -77,7 +76,7 @@ jobs:
         id: validate
         uses: actions/github-script@v9
         env:
-          PR_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request.number }}
+          PR_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -136,7 +135,7 @@ jobs:
         id: check-collection
         uses: actions/github-script@v9
         env:
-          PR_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request.number }}
+          PR_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -162,7 +161,7 @@ jobs:
     with:
       control-plane-workflow: oblt-aw-automerge.yml
       platform-additional-instructions: |
-        Target pull request number: ${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request.number }}.
+        Target pull request number: ${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}.
 
   approve:
     needs: [verify, check-dependency-collection, resolve-apm-assets]
@@ -180,7 +179,7 @@ jobs:
       allowed-bot-users: ${{ inputs.ingress-allowed-pr-authors-csv }}
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
       prompt: |
-        For pull request #${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request.number }}: evaluate automerge eligibility.
+        For pull request #${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}: evaluate automerge eligibility.
 
         This PR already passed automerge validation in the workflow (GITHUB_TOKEN) for author, label, draft/fork/ref, and dependency collection `${{ needs.check-dependency-collection.outputs.collection-id }}` (file-path classification; no extra repo labels).
         Do not call check-run or commit status APIs. Required checks are enforced by GitHub when auto-merge is enabled.
@@ -220,7 +219,7 @@ jobs:
         uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST: ${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request.number }}
+          PULL_REQUEST: ${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}
           MERGE_LABELS: "oblt-aw/ai/merge-ready"
           UPDATE_LABELS: "oblt-aw/ai/merge-ready"
           MERGE_METHOD: squash
@@ -248,7 +247,7 @@ jobs:
       - name: Enable merge when ready (merge queue fallback)
         env:
           GH_TOKEN: ${{ steps.create-token.outputs.token }}
-          PR_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json != '' && inputs.ingress-event-payload-json || toJSON(github.event)).pull_request.number }}
+          PR_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/oblt-aw-dependency-review.yml
+++ b/.github/workflows/oblt-aw-dependency-review.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false
@@ -105,12 +104,18 @@ jobs:
 
       - name: Re-apply merge-ready label to emit installation-token labeled event
         uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}
         with:
           github-token: ${{ steps.create-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isFinite(prNumber) || prNumber <= 0) {
+              core.info('No pull_request.number in relayed event; skipping re-apply.');
+              return;
+            }
             const { data: issue } = await github.rest.issues.get({
               owner,
               repo,

--- a/.github/workflows/oblt-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/oblt-aw-duplicate-issue-detector.yml
@@ -15,9 +15,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
+++ b/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
@@ -15,9 +15,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-issue-fixer.yml
+++ b/.github/workflows/oblt-aw-issue-fixer.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-issue-triage.yml
+++ b/.github/workflows/oblt-aw-issue-triage.yml
@@ -15,9 +15,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-mention-in-issue.yml
+++ b/.github/workflows/oblt-aw-mention-in-issue.yml
@@ -15,9 +15,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false
@@ -262,12 +261,18 @@ jobs:
 
       - name: Re-apply fix-ready label to emit installation-token labeled event
         uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json).issue.number }}
         with:
           github-token: ${{ steps.create-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const issueNumber = context.issue.number;
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
+              core.info('No issue.number in relayed event; skipping re-apply.');
+              return;
+            }
             const { data: issue } = await github.rest.issues.get({
               owner,
               repo,

--- a/.github/workflows/oblt-aw-security-detector.yml
+++ b/.github/workflows/oblt-aw-security-detector.yml
@@ -15,9 +15,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-security-fixer.yml
+++ b/.github/workflows/oblt-aw-security-fixer.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false

--- a/.github/workflows/oblt-aw-security-triage.yml
+++ b/.github/workflows/oblt-aw-security-triage.yml
@@ -14,9 +14,8 @@ on:
         default: ''
       ingress-event-payload-json:
         description: Relayed github.event JSON from oblt-aw-ingress
-        required: false
+        required: true
         type: string
-        default: ''
       ingress-allowed-pr-authors-csv:
         description: Allowed PR bot logins from oblt-aw-ingress prelude
         required: false
@@ -152,12 +151,18 @@ jobs:
 
       - name: Re-apply fix-ready label to emit installation-token labeled event
         uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ fromJSON(inputs.ingress-event-payload-json).issue.number }}
         with:
           github-token: ${{ steps.create-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const issueNumber = context.issue.number;
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
+              core.info('No issue.number in relayed event; skipping re-apply.');
+              return;
+            }
             const { data: issue } = await github.rest.issues.get({
               owner,
               repo,

--- a/scripts/docs/issue-menu/evaluate-trigger.js
+++ b/scripts/docs/issue-menu/evaluate-trigger.js
@@ -15,11 +15,13 @@
 
 'use strict';
 
+const { relayedPayload } = require('../lib/relayed-event.js');
 const { parseMenuState } = require('./lib.js');
 
 module.exports = async ({ context, core }) => {
-  const body = context.payload.comment.body || '';
-  const previousBody = context.payload.changes?.body?.from || '';
+  const payload = relayedPayload(context);
+  const body = payload.comment?.body || '';
+  const previousBody = payload.changes?.body?.from || '';
 
   const previousState = parseMenuState(previousBody);
   const currentState = parseMenuState(body);

--- a/scripts/docs/issue-menu/post-menu.js
+++ b/scripts/docs/issue-menu/post-menu.js
@@ -15,14 +15,16 @@
 
 'use strict';
 
+const { relayedPayload } = require('../lib/relayed-event.js');
 const { upsertMenuComment } = require('./lib.js');
 
 module.exports = async ({ github, context, core }) => {
-  const workflowDispatchIssueNumber = context.payload.inputs?.issue_number;
+  const payload = relayedPayload(context);
+  const workflowDispatchIssueNumber = payload.inputs?.issue_number;
   const issueNumber =
     context.eventName === 'workflow_dispatch'
       ? Number(workflowDispatchIssueNumber)
-      : context.payload.issue.number;
+      : payload.issue?.number;
 
   if (!issueNumber) {
     core.setFailed('Issue number is required for workflow_dispatch runs.');

--- a/scripts/docs/issue-menu/refresh-after-docs-issue-scope.js
+++ b/scripts/docs/issue-menu/refresh-after-docs-issue-scope.js
@@ -15,10 +15,11 @@
 
 'use strict';
 
+const { relayedPayload } = require('../lib/relayed-event.js');
 const { upsertMenuComment } = require('./lib.js');
 
 module.exports = async ({ github, context, core }) => {
-  const issueNumber = context.payload.issue.number;
+  const issueNumber = relayedPayload(context).issue?.number;
   const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
   const issueScopeResult = process.env.ISSUE_SCOPE_RESULT || '';
 

--- a/scripts/docs/issue-menu/refresh-after-docs-triage.js
+++ b/scripts/docs/issue-menu/refresh-after-docs-triage.js
@@ -15,10 +15,11 @@
 
 'use strict';
 
+const { relayedPayload } = require('../lib/relayed-event.js');
 const { upsertMenuComment } = require('./lib.js');
 
 module.exports = async ({ github, context, core }) => {
-  const issueNumber = context.payload.issue.number;
+  const issueNumber = relayedPayload(context).issue?.number;
   const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
   const triageResult = process.env.TRIAGE_RESULT || '';
 

--- a/scripts/docs/issue-menu/refresh-after-trigger.js
+++ b/scripts/docs/issue-menu/refresh-after-trigger.js
@@ -15,10 +15,11 @@
 
 'use strict';
 
+const { relayedPayload } = require('../lib/relayed-event.js');
 const { upsertMenuComment } = require('./lib.js');
 
 module.exports = async ({ github, context, core }) => {
-  const issueNumber = context.payload.issue.number;
+  const issueNumber = relayedPayload(context).issue?.number;
   const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
   const statusOverrides = {};
 

--- a/scripts/docs/lib/relayed-event.js
+++ b/scripts/docs/lib/relayed-event.js
@@ -15,21 +15,17 @@
 
 'use strict';
 
-const { relayedPayload } = require('../lib/relayed-event.js');
-const { upsertMenuComment } = require('./lib.js');
+/**
+ * Original webhook payload for workflow_call routes that relay
+ * ingress-event-payload-json. github-script context.payload is the
+ * workflow_call envelope, not the consumer pull_request/issue event.
+ */
+function relayedPayload(context) {
+  const raw = process.env.INGRESS_EVENT_JSON;
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    return JSON.parse(raw);
+  }
+  return context.payload;
+}
 
-module.exports = async ({ github, context, core }) => {
-  const pullRequestNumber = relayedPayload(context).issue?.number;
-  const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-  await upsertMenuComment({
-    core,
-    createIfMissing: false,
-    github,
-    context,
-    pullRequestNumber,
-    statusOverrides: {
-      docsReview: { detailsUrl: progressUrl, status: 'in_progress' },
-    },
-  });
-};
+module.exports = { relayedPayload };

--- a/scripts/docs/pr-menu/evaluate-trigger.js
+++ b/scripts/docs/pr-menu/evaluate-trigger.js
@@ -15,13 +15,20 @@
 
 'use strict';
 
+const { relayedPayload } = require('../lib/relayed-event.js');
 const { parseMenuState } = require('./lib.js');
 
 module.exports = async ({ github, context, core }) => {
+  const payload = relayedPayload(context);
+  const pullNumber = payload.issue?.number;
+  if (!pullNumber) {
+    core.setFailed('Pull request number is required.');
+    return;
+  }
   const { data: pullRequest } = await github.rest.pulls.get({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    pull_number: context.payload.issue.number,
+    pull_number: pullNumber,
   });
   const baseRepoFullName = `${context.repo.owner}/${context.repo.repo}`;
   const isForkPR = pullRequest.head.repo.full_name !== baseRepoFullName;
@@ -43,8 +50,8 @@ module.exports = async ({ github, context, core }) => {
     }
   }
 
-  const body = context.payload.comment.body || '';
-  const previousBody = context.payload.changes?.body?.from || '';
+  const body = payload.comment?.body || '';
+  const previousBody = payload.changes?.body?.from || '';
 
   const previousState = parseMenuState(previousBody);
   const currentState = parseMenuState(body);

--- a/scripts/docs/pr-menu/post-menu.js
+++ b/scripts/docs/pr-menu/post-menu.js
@@ -15,15 +15,17 @@
 
 'use strict';
 
+const { relayedPayload } = require('../lib/relayed-event.js');
 const { upsertMenuComment } = require('./lib.js');
 
 module.exports = async ({ github, context, core }) => {
-  const workflowDispatchPrNumber = context.payload.inputs?.pull_request_number;
+  const payload = relayedPayload(context);
+  const workflowDispatchPrNumber = payload.inputs?.pull_request_number;
   const envPrNumber = process.env.PULL_REQUEST_NUMBER;
   const pullRequestNumber = Number(
     context.eventName === 'workflow_dispatch'
       ? workflowDispatchPrNumber
-      : envPrNumber || context.payload.pull_request?.number,
+      : envPrNumber || payload.pull_request?.number || payload.issue?.number,
   );
 
   if (!pullRequestNumber || Number.isNaN(pullRequestNumber)) {

--- a/scripts/docs/pr-menu/refresh-after-docs-review.js
+++ b/scripts/docs/pr-menu/refresh-after-docs-review.js
@@ -15,10 +15,11 @@
 
 'use strict';
 
+const { relayedPayload } = require('../lib/relayed-event.js');
 const { upsertMenuComment } = require('./lib.js');
 
 module.exports = async ({ github, context, core }) => {
-  const pullRequestNumber = context.payload.issue.number;
+  const pullRequestNumber = relayedPayload(context).issue?.number;
   const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
   const docsReviewResult = process.env.DOCS_REVIEW_RESULT || '';
 


### PR DESCRIPTION
## Summary

- Fix `TypeError` in dependency-review (and similar) label re-apply steps by resolving PR/issue numbers from `ingress-event-payload-json` instead of `context.payload` / `context.issue`, which are not populated under nested `workflow_call`.
- Require `ingress-event-payload-json` on all routed `oblt-aw-*` and `docs-aw-*` reusables (aligned with ingress contracts) and drop `toJSON(github.event)` fallbacks.
- Add `scripts/docs/lib/relayed-event.js` and wire docs AI menu `github-script` steps to pass `INGRESS_EVENT_JSON`.

## Test plan

- [ ] Re-run a dependency-review workflow that applies `oblt-aw/ai/merge-ready` and confirm `signal-dependency-review-followups` completes without `context.payload.pull_request` errors.
- [ ] Verify security-triage and res-not-accessible triage follow-up label re-apply jobs resolve issue numbers correctly.
- [ ] Smoke-test docs PR/issue AI menu paths routed via `docs-aw-ingress`.

Fixes https://github.com/elastic/observability-github-settings/actions/runs/26874961713/job/79260743662

Related issue: https://github.com/elastic/observability-robots/issues/4595
