### PR TITLE
Inject relayed GitHub context into gh-aw agent workflows

### DIFF
--- a/.github/workflows/aw-resolve-apm-assets.yml
+++ b/.github/workflows/aw-resolve-apm-assets.yml
@@ -30,6 +30,21 @@ on:
         required: false
         type: boolean
         default: true
+      ingress-event-name:
+        description: Relayed github.event_name from ingress (injected into gh-aw prompt context)
+        required: false
+        type: string
+        default: ""
+      ingress-event-action:
+        description: Relayed github.event.action from ingress (injected into gh-aw prompt context)
+        required: false
+        type: string
+        default: ""
+      ingress-event-payload-json:
+        description: Relayed github.event JSON from ingress (injected into gh-aw prompt context)
+        required: false
+        type: string
+        default: ""
     outputs:
       apm-manifest-present:
         description: True when the consumer repository contains apm.yml or apm.yaml
@@ -80,6 +95,7 @@ jobs:
           token: ${{ github.token }}
           sparse-checkout: |
             scripts/apm_agentic_assets.py
+            scripts/ingress_github_context.py
             scripts/resolve_apm_agentic_assets.py
             scripts/workflow_registry.py
             scripts/oblt_aw_route_specs.py
@@ -159,4 +175,7 @@ jobs:
           CONTROL_PLANE_CONFIG_DIR: ${{ github.workspace }}/_oblt-aw/config
           PLATFORM_ADDITIONAL_INSTRUCTIONS: ${{ inputs.platform-additional-instructions }}
           PLATFORM_INPUTS_JSON: ${{ inputs.platform-inputs-json }}
+          INGRESS_EVENT_NAME: ${{ inputs.ingress-event-name }}
+          INGRESS_EVENT_ACTION: ${{ inputs.ingress-event-action }}
+          INGRESS_EVENT_PAYLOAD_JSON: ${{ inputs.ingress-event-payload-json }}
         run: python _oblt-aw/scripts/resolve_apm_agentic_assets.py

--- a/.github/workflows/docs-aw-ai-menu.yml
+++ b/.github/workflows/docs-aw-ai-menu.yml
@@ -159,6 +159,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: docs-aw-ai-menu.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
 
   run-docs-triage:
     name: Docs AI / triage
@@ -173,6 +176,7 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v1
     with:
       additional-instructions: ${{ needs.resolve-apm-assets-triage.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets-triage.outputs.resolved-setup-commands-json), ' && ') }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 
@@ -185,6 +189,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: docs-aw-ai-menu.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
 
   run-docs-issue-scope:
     name: Docs AI / issue scope
@@ -200,6 +207,7 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/gh-aw-docs-issue-scope.lock.yml@v1
     with:
       additional-instructions: ${{ needs.resolve-apm-assets-issue-scope.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets-issue-scope.outputs.resolved-setup-commands-json), ' && ') }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/docs-aw-pr-ai-menu.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu.yml
@@ -188,6 +188,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: docs-aw-pr-ai-menu.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         This repository stores documentation as markdown across the repository.
         Prefer concise, high-signal review comments with exact replacement text when possible.
@@ -206,6 +209,7 @@ jobs:
     with:
       review-scope: repo-wide-markdown
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/oblt-aw-agent-suggestions.yml
+++ b/.github/workflows/oblt-aw-agent-suggestions.yml
@@ -40,6 +40,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-agent-suggestions.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Additional requirements for this repository:
 
@@ -66,4 +69,5 @@ jobs:
     with:
       title-prefix: "[oblt-aw][agent-suggestions]"
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets: inherit

--- a/.github/workflows/oblt-aw-autodoc.yml
+++ b/.github/workflows/oblt-aw-autodoc.yml
@@ -42,6 +42,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-autodoc.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Your task is to analyze ALL documentation in this repository, identify gaps and areas for improvement, and file an issue with concrete findings.
 
@@ -81,6 +84,7 @@ jobs:
       lookback-window: 1 day ago
       title-prefix: "[oblt-aw][autodoc]"
       additional-instructions: ${{ needs.resolve-apm-assets-audit.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets-audit.outputs.resolved-setup-commands-json), ' && ') }}
     secrets: inherit
 
   resolve-apm-assets-fix:
@@ -91,6 +95,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-autodoc.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Your task is to implement the documentation improvements described in the issue.
 
@@ -138,6 +145,7 @@ jobs:
       target-issue-number: ${{ needs.audit.outputs.created_issue_number }}
       draft-prs: true
       additional-instructions: ${{ needs.resolve-apm-assets-fix.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets-fix.outputs.resolved-setup-commands-json), ' && ') }}
     secrets: inherit
 
   # Step 3: Finalize autodoc PR — assign reviewer and apply labels

--- a/.github/workflows/oblt-aw-automerge.yml
+++ b/.github/workflows/oblt-aw-automerge.yml
@@ -160,6 +160,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-automerge.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Target pull request number: ${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}.
 
@@ -178,6 +181,7 @@ jobs:
     with:
       allowed-bot-users: ${{ inputs.ingress-allowed-pr-authors-csv }}
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
       prompt: |
         For pull request #${{ fromJSON(inputs.ingress-event-payload-json).pull_request.number }}: evaluate automerge eligibility.
 

--- a/.github/workflows/oblt-aw-dependency-review.yml
+++ b/.github/workflows/oblt-aw-dependency-review.yml
@@ -41,6 +41,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-dependency-review.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Noop when not applicable (mandatory):
         - If the PR has NO dependency updates to review (e.g. no version bumps in manifest files, no changes to lockfiles that indicate dependency updates, or changes that do not match any supported ecosystem), you MUST call `noop` — do NOT create any comment.
@@ -82,6 +85,7 @@ jobs:
       allowed-bot-users: ${{ inputs.ingress-allowed-pr-authors-csv }}
       classification-labels: "oblt-aw/ai/merge-ready"
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/oblt-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/oblt-aw-duplicate-issue-detector.yml
@@ -41,6 +41,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-duplicate-issue-detector.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
 
   duplicate-issue-detector:
     needs: [resolve-apm-assets]

--- a/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
+++ b/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
@@ -44,6 +44,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-estc-pr-buildkite-detective.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         If a step fails, check if the failure is reported as a GitHub issue labeled `flaky-test`. Reference the GitHub issue if so.
 
@@ -61,6 +64,7 @@ jobs:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-estc-pr-buildkite-detective.lock.yml@copilot/reduce-comment-spamming
     with:
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}

--- a/.github/workflows/oblt-aw-issue-fixer.yml
+++ b/.github/workflows/oblt-aw-issue-fixer.yml
@@ -38,6 +38,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-issue-fixer.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Your task is to fix issues requested through `/ai implement` comments.
 
@@ -91,6 +94,7 @@ jobs:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
     with:
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets: inherit
 
   request-reviewers:

--- a/.github/workflows/oblt-aw-issue-triage.yml
+++ b/.github/workflows/oblt-aw-issue-triage.yml
@@ -42,6 +42,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-issue-triage.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
 
   issue-triage:
     needs: [resolve-apm-assets]
@@ -54,5 +57,6 @@ jobs:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/oblt-aw-mention-in-issue.yml
+++ b/.github/workflows/oblt-aw-mention-in-issue.yml
@@ -42,6 +42,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-mention-in-issue.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
 
   mention-in-issue:
     needs: [resolve-apm-assets]
@@ -61,5 +64,6 @@ jobs:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@main
     with:
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml
@@ -61,6 +61,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-resource-not-accessible-by-integration-detector.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         **Error Context:**
         You are analyzing preflight search results for the exact phrase "Resource not accessible by integration" in GitHub Actions workflow logs. This error typically indicates permission or token scope issues when workflows access protected resources (e.g., secrets, environments, or repository settings).

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml
@@ -38,6 +38,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-resource-not-accessible-by-integration-fixer.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Your task is to fix issues labeled for the "Resource not accessible by integration" problem.
 
@@ -92,6 +95,7 @@ jobs:
     with:
       allowed-bot-users: ${{ inputs.ingress-allowed-issue-authors-csv }}
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets: inherit
 
   request-reviewers:

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml
@@ -42,6 +42,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-resource-not-accessible-by-integration-triage.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Your task is to triage issues that carry the detector label `oblt-aw/detector/res-not-accessible-by-integration` and determine if they are related to "Resource not accessible by integration" errors in GitHub Actions workflows.
 
@@ -240,6 +243,7 @@ jobs:
       allowed-bot-users: ${{ inputs.ingress-allowed-issue-authors-csv }}
       classification-labels: "oblt-aw/triage/res-not-accessible-by-integration,oblt-aw/triage/other,oblt-aw/triage/needs-info,oblt-aw/ai/fix-ready"
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/oblt-aw-security-fixer.yml
+++ b/.github/workflows/oblt-aw-security-fixer.yml
@@ -41,19 +41,10 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-security-fixer.yml
-
-  security-issue-fixer:
-    needs: [resolve-apm-assets]
-    permissions:
-      actions: read
-      contents: write
-      discussions: write
-      issues: write
-      pull-requests: write
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
-    with:
-      allowed-bot-users: ${{ inputs.ingress-allowed-issue-authors-csv }}
-      additional-instructions: |
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
+      platform-additional-instructions: |
         Your task is to fix security issues labeled for remediation. This workflow uses agentic workflows from elastic/ai-github-actions.
 
         **Execution Preconditions:**
@@ -90,6 +81,20 @@ jobs:
         **Merge Policy:**
         - Do not merge automatically.
         - Do not perform merge operations in this workflow.
+
+  security-issue-fixer:
+    needs: [resolve-apm-assets]
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-fixer.lock.yml@main
+    with:
+      allowed-bot-users: ${{ inputs.ingress-allowed-issue-authors-csv }}
+      additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets: inherit
 
   request-reviewers:

--- a/.github/workflows/oblt-aw-security-triage.yml
+++ b/.github/workflows/oblt-aw-security-triage.yml
@@ -42,6 +42,9 @@ jobs:
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-security-triage.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Your task is to triage newly opened security-related issues in this repository. Security issues include vulnerabilities in GitHub Actions workflows and shell scripts: injection (expression, command, YAML), secret management (token exposure via CLI args, secrets in command strings), supply chain (action pinning, checksums), and least privilege (excessive permissions).
 
@@ -130,6 +133,7 @@ jobs:
       allowed-bot-users: ${{ inputs.ingress-allowed-issue-authors-csv }}
       classification-labels: "oblt-aw/triage/security-injection,oblt-aw/triage/security-secrets,oblt-aw/triage/security-supply-chain,oblt-aw/triage/security-least-privilege,oblt-aw/triage/other,oblt-aw/triage/needs-info,oblt-aw/ai/fix-ready"
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 

--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -20,6 +20,9 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 | `platform-additional-instructions` | string | `""` | Control-plane baseline text for this agent invocation (prepended before repo APM instructions) |
 | `platform-inputs-json` | string | `"{}"` | JSON object of platform inputs; APM `inputs` override per key |
 | `install-apm-packages` | boolean | `true` | Run `apm install` when `apm.yml` is present |
+| `ingress-event-name` | string | `""` | Relayed `github.event_name` from ingress (prepended gh-aw context block) |
+| `ingress-event-action` | string | `""` | Relayed `github.event.action` from ingress |
+| `ingress-event-payload-json` | string | `""` | Relayed `github.event` JSON from ingress; drives authoritative PR/issue numbers in agent prompts and optional PR checkout setup commands |
 
 ### Outputs
 
@@ -28,31 +31,22 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 | `apm-manifest-present` | Consumer has `apm.yml` / `apm.yaml` |
 | `apm-extension-present` | Manifest contains `x-oblt-aw` |
 | `asset-source` | `none`, `common`, or `workflow` |
-| `resolved-additional-instructions` | Merged platform + APM instructions |
+| `resolved-additional-instructions` | Relayed ingress context (when present), then merged platform + APM instructions |
 | `resolved-inputs-json` | Merged platform + APM inputs |
-| `resolved-setup-commands-json` | JSON array of shell commands from the selected asset block (`setup-commands` inline string/list and optional `setup-commands-file`) |
+| `resolved-setup-commands-json` | Relayed PR checkout commands (when applicable), then APM `setup-commands` |
 
-### Typical caller pattern
+### Relayed GitHub context
 
-Place each `resolve-apm-assets` job **immediately before** the `gh-aw-*` job it feeds, after any prerequisite gates (verify, discover, evaluate-trigger, etc.). Use the **same `if` expression** on resolve and agent so APM install/resolution runs only when the agent will.
+Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends `git fetch` / `git checkout` commands to `resolved-setup-commands-json`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
 
 ```yaml
-jobs:
-  prelude:
-    uses: ./.github/workflows/aw-prelude.yml
-    with:
-      control-plane-workflow: oblt-aw-example.yml
-
-  # ... optional intermediate jobs (verify, discover, menu scripts, etc.) ...
-
   resolve-apm-assets:
-    needs: [prelude]  # plus any jobs the agent also needs
-    if: >-
-      needs.prelude.outputs.proceed == 'true' &&
-      <same conditions as the agent job below>
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-example.yml
+      ingress-event-name: ${{ inputs.ingress-event-name }}
+      ingress-event-action: ${{ inputs.ingress-event-action }}
+      ingress-event-payload-json: ${{ inputs.ingress-event-payload-json }}
       platform-additional-instructions: |
         Platform prompt for this agent invocation.
 
@@ -64,7 +58,10 @@ jobs:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-example.lock.yml@main
     with:
       additional-instructions: ${{ needs.resolve-apm-assets.outputs.resolved-additional-instructions }}
+      setup-commands: ${{ join(fromJSON(needs.resolve-apm-assets.outputs.resolved-setup-commands-json), ' && ') }}
 ```
+
+Place each `resolve-apm-assets` job **immediately before** the `gh-aw-*` job it feeds, after any prerequisite gates (verify, discover, evaluate-trigger, etc.). Use the **same `if` expression** on resolve and agent so APM install/resolution runs only when the agent will.
 
 Examples with upstream gates: [oblt-aw-automerge.yml](../../.github/workflows/oblt-aw-automerge.yml) (resolve after verify + dependency collection), [oblt-aw-resource-not-accessible-by-integration-detector.yml](../../.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml) (resolve after discover). Multi-agent wrappers use one resolve job per `gh-aw-*` invocation — see [oblt-aw-autodoc.yml](../../.github/workflows/oblt-aw-autodoc.yml).
 
@@ -74,3 +71,4 @@ Examples with upstream gates: [oblt-aw-automerge.yml](../../.github/workflows/ob
 - [APM agentic assets architecture](../architecture/apm-agentic-assets.md)
 - [Agentic Workflow Prelude](aw-prelude.md)
 - [scripts/resolve_apm_agentic_assets.py](../../scripts/resolve_apm_agentic_assets.py)
+- [scripts/ingress_github_context.py](../../scripts/ingress_github_context.py)

--- a/scripts/ingress_github_context.py
+++ b/scripts/ingress_github_context.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# Copyright 2026-2027 Elasticsearch B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Build gh-aw prompt and setup overrides from relayed ingress event JSON."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RelayedGitHubContext:
+    event_name: str | None
+    event_action: str | None
+    pull_request_number: int | None
+    pull_request_title: str | None
+    pull_request_head_ref: str | None
+    pull_request_head_sha: str | None
+    issue_number: int | None
+    comment_id: int | None
+    discussion_number: int | None
+
+    @property
+    def has_actionable_target(self) -> bool:
+        return any(
+            value is not None
+            for value in (
+                self.pull_request_number,
+                self.issue_number,
+                self.comment_id,
+                self.discussion_number,
+            )
+        )
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        parsed = int(value.strip())
+        return parsed if parsed > 0 else None
+    return None
+
+
+def _optional_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def parse_relayed_ingress_payload(raw: str) -> dict[str, Any] | None:
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        payload: Any = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def extract_relayed_github_context(
+    payload: dict[str, Any],
+    *,
+    ingress_event_name: str | None = None,
+    ingress_event_action: str | None = None,
+) -> RelayedGitHubContext:
+    pull_request = payload.get("pull_request")
+    issue = payload.get("issue")
+    comment = payload.get("comment")
+    discussion = payload.get("discussion")
+    inputs = payload.get("inputs")
+
+    pull_request_number: int | None = None
+    pull_request_title: str | None = None
+    pull_request_head_ref: str | None = None
+    pull_request_head_sha: str | None = None
+
+    if isinstance(pull_request, dict):
+        pull_request_number = _positive_int(pull_request.get("number"))
+        pull_request_title = _optional_str(pull_request.get("title"))
+        head = pull_request.get("head")
+        if isinstance(head, dict):
+            pull_request_head_ref = _optional_str(head.get("ref"))
+            pull_request_head_sha = _optional_str(head.get("sha"))
+
+    issue_number = (
+        _positive_int(issue.get("number")) if isinstance(issue, dict) else None
+    )
+    if (
+        pull_request_number is None
+        and isinstance(issue, dict)
+        and issue.get("pull_request") is not None
+    ):
+        pull_request_number = issue_number
+        pull_request_title = _optional_str(issue.get("title"))
+
+    if isinstance(inputs, dict):
+        if pull_request_number is None:
+            pull_request_number = _positive_int(inputs.get("pull_request_number"))
+        if issue_number is None:
+            issue_number = _positive_int(inputs.get("issue_number"))
+
+    event_name = _optional_str(ingress_event_name) or _optional_str(
+        payload.get("event_name")
+    )
+    event_action = _optional_str(ingress_event_action) or _optional_str(
+        payload.get("action")
+    )
+
+    return RelayedGitHubContext(
+        event_name=event_name,
+        event_action=event_action,
+        pull_request_number=pull_request_number,
+        pull_request_title=pull_request_title,
+        pull_request_head_ref=pull_request_head_ref,
+        pull_request_head_sha=pull_request_head_sha,
+        issue_number=issue_number,
+        comment_id=_positive_int(comment.get("id"))
+        if isinstance(comment, dict)
+        else None,
+        discussion_number=_positive_int(discussion.get("number"))
+        if isinstance(discussion, dict)
+        else None,
+    )
+
+
+def build_relayed_context_instructions(ctx: RelayedGitHubContext) -> str:
+    if not ctx.has_actionable_target:
+        return ""
+
+    lines = [
+        "## Relayed ingress context (authoritative)",
+        "",
+        "This run reached the agent through the oblt-aw entrypoint (`workflow_dispatch` relay).",
+        "The built-in GitHub context block above may show empty PR/issue identifiers — ignore those empty values.",
+        "Use the relayed values below for MCP calls, analysis, comments, labels, and checkout.",
+        "",
+    ]
+
+    if ctx.event_name:
+        lines.append(f"- **relay-event-name**: {ctx.event_name}")
+    if ctx.event_action:
+        lines.append(f"- **relay-event-action**: {ctx.event_action}")
+    if ctx.pull_request_number is not None:
+        lines.append(f"- **pull-request-number**: {ctx.pull_request_number}")
+    if ctx.pull_request_title:
+        lines.append(f"- **pull-request-title**: {ctx.pull_request_title}")
+    if ctx.pull_request_head_ref:
+        lines.append(f"- **pull-request-head-ref**: {ctx.pull_request_head_ref}")
+    if ctx.pull_request_head_sha:
+        lines.append(f"- **pull-request-head-sha**: {ctx.pull_request_head_sha}")
+    if ctx.issue_number is not None:
+        lines.append(f"- **issue-number**: {ctx.issue_number}")
+    if ctx.comment_id is not None:
+        lines.append(f"- **comment-id**: {ctx.comment_id}")
+    if ctx.discussion_number is not None:
+        lines.append(f"- **discussion-number**: {ctx.discussion_number}")
+
+    lines.extend(
+        [
+            "",
+            "Rules:",
+            "- Do not emit `missing_data` for pull request or issue numbers when relayed values above are present.",
+            "- Prefer GitHub MCP tools (`pull_request_read`, `issue_read`, and related methods) with these relayed numbers.",
+            "- Treat relayed pull-request/issue numbers as the workflow target even when built-in context shows `#` or blank values.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_relayed_setup_commands(ctx: RelayedGitHubContext) -> list[str]:
+    if ctx.pull_request_number is None or not ctx.pull_request_head_ref:
+        return []
+
+    ref = ctx.pull_request_head_ref
+    pr_number = ctx.pull_request_number
+    return [
+        "set -euo pipefail",
+        f"git fetch origin {shlex.quote(f'pull/{pr_number}/head:{ref}')}",
+        f"git checkout {shlex.quote(ref)}",
+    ]
+
+
+def apply_relayed_ingress_context(
+    payload_json: str,
+    additional_instructions: str,
+    setup_commands: list[str],
+    *,
+    ingress_event_name: str | None = None,
+    ingress_event_action: str | None = None,
+) -> tuple[str, list[str]]:
+    payload = parse_relayed_ingress_payload(payload_json)
+    if payload is None:
+        return additional_instructions, setup_commands
+
+    ctx = extract_relayed_github_context(
+        payload,
+        ingress_event_name=ingress_event_name,
+        ingress_event_action=ingress_event_action,
+    )
+    relayed_block = build_relayed_context_instructions(ctx)
+    if not relayed_block:
+        return additional_instructions, setup_commands
+
+    relayed_setup = build_relayed_setup_commands(ctx)
+    merged_setup = relayed_setup + setup_commands
+
+    platform = additional_instructions.strip()
+    merged_additional = f"{relayed_block}\n\n{platform}" if platform else relayed_block
+    return merged_additional, merged_setup

--- a/scripts/resolve_apm_agentic_assets.py
+++ b/scripts/resolve_apm_agentic_assets.py
@@ -24,6 +24,9 @@ Environment:
   REPO_ROOT            Repository root (default: cwd)
   PLATFORM_ADDITIONAL_INSTRUCTIONS  Multiline platform baseline text
   PLATFORM_INPUTS_JSON JSON object of platform workflow_call inputs
+  INGRESS_EVENT_NAME  Relayed github.event_name from ingress (optional)
+  INGRESS_EVENT_ACTION  Relayed github.event.action from ingress (optional)
+  INGRESS_EVENT_PAYLOAD_JSON  Relayed github.event JSON from ingress (optional)
   CONTROL_PLANE_CONFIG_DIR  Optional path to config/ for registry validation
 """
 
@@ -37,6 +40,7 @@ from typing import Any, cast
 
 from apm_agentic_assets import resolve_agentic_assets
 from common import append_multiline_github_output, write_outputs
+from ingress_github_context import apply_relayed_ingress_context
 
 
 def main() -> int:
@@ -88,8 +92,21 @@ def main() -> int:
         return 1
 
     additional = resolved["additional_instructions"]
+    setup_commands = list(resolved["setup_commands"])
+
+    ingress_payload = os.environ.get("INGRESS_EVENT_PAYLOAD_JSON", "").strip()
+    if ingress_payload:
+        additional, setup_commands = apply_relayed_ingress_context(
+            ingress_payload,
+            additional,
+            setup_commands,
+            ingress_event_name=os.environ.get("INGRESS_EVENT_NAME", "").strip() or None,
+            ingress_event_action=os.environ.get("INGRESS_EVENT_ACTION", "").strip()
+            or None,
+        )
+
     inputs_json = json.dumps(resolved["inputs"], ensure_ascii=False)
-    setup_json = json.dumps(resolved["setup_commands"], ensure_ascii=False)
+    setup_json = json.dumps(setup_commands, ensure_ascii=False)
 
     write_outputs(
         {

--- a/tests/test_ingress_github_context.py
+++ b/tests/test_ingress_github_context.py
@@ -1,0 +1,82 @@
+"""Unit tests for scripts/ingress_github_context.py"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+_root = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, str(_root / "scripts"))
+
+import ingress_github_context as igc  # noqa: E402
+
+
+def test_parse_relayed_payload_accepts_double_encoded_json() -> None:
+    payload = {
+        "action": "synchronize",
+        "pull_request": {"number": 42, "title": "Fix deps"},
+    }
+    raw = json.dumps(json.dumps(payload))
+    parsed = igc.parse_relayed_ingress_payload(raw)
+    assert parsed == payload
+
+
+def test_extract_pull_request_context_from_relayed_event() -> None:
+    payload = {
+        "action": "synchronize",
+        "pull_request": {
+            "number": 123,
+            "title": "Update lodash",
+            "head": {"ref": "dependabot/npm/lodash", "sha": "abc123"},
+        },
+    }
+    ctx = igc.extract_relayed_github_context(payload)
+    assert ctx.pull_request_number == 123
+    assert ctx.pull_request_title == "Update lodash"
+    assert ctx.pull_request_head_ref == "dependabot/npm/lodash"
+    assert ctx.event_action == "synchronize"
+
+
+def test_extract_issue_context_from_pr_issue_object() -> None:
+    payload = {
+        "action": "created",
+        "issue": {"number": 99, "title": "Docs", "pull_request": {}},
+    }
+    ctx = igc.extract_relayed_github_context(
+        payload, ingress_event_name="issue_comment"
+    )
+    assert ctx.pull_request_number == 99
+    assert ctx.issue_number == 99
+
+
+def test_apply_relayed_context_prepends_instructions_and_checkout() -> None:
+    payload = {
+        "action": "opened",
+        "pull_request": {
+            "number": 7,
+            "title": "Test",
+            "head": {"ref": "feature/test", "sha": "deadbeef"},
+        },
+    }
+    additional, setup = igc.apply_relayed_ingress_context(
+        json.dumps(payload),
+        "Platform rules",
+        ["npm ci"],
+        ingress_event_name="pull_request",
+        ingress_event_action="opened",
+    )
+    assert "## Relayed ingress context (authoritative)" in additional
+    assert "- **pull-request-number**: 7" in additional
+    assert additional.index("Relayed ingress context") < additional.index(
+        "Platform rules"
+    )
+    assert setup[0] == "set -euo pipefail"
+    assert "pull/7/head:feature/test" in setup[1]
+    assert setup[-1] == "npm ci"
+
+
+def test_apply_relayed_context_noop_without_target() -> None:
+    additional, setup = igc.apply_relayed_ingress_context("{}", "Platform rules", [])
+    assert additional == "Platform rules"
+    assert setup == []


### PR DESCRIPTION
## Summary

- Parse `ingress-event-payload-json` in `aw-resolve-apm-assets` and prepend an authoritative **Relayed ingress context** block to `additional-instructions` so gh-aw agents get PR/issue numbers under the existing `workflow_dispatch` entrypoint relay.
- For pull requests, prepend `git fetch` / `git checkout` setup commands when gh-aw locks accept `setup-commands` (dependency review, automerge, issue triage/fixer, docs menus, etc.).
- Wire all `*-aw-*` wrappers to pass `ingress-event-name`, `ingress-event-action`, and `ingress-event-payload-json` into resolve jobs; fix `oblt-aw-security-fixer` to use resolved instructions.

## Test plan

- [x] `pytest tests/test_ingress_github_context.py`
- [x] Full test suite (`157 passed`)
- [x] `python3 scripts/validate_aw_workflow_prelude.py`
- [x] `python3 scripts/validate_aw_workflow_resolve_apm_assets.py`
- [ ] Merge to `main`, then trigger dependency review on a consumer PR and confirm the agent prompt includes relayed PR context (no `missing_data` for `pull-request-number`)

Related issue: https://github.com/elastic/observability-robots/issues/3614

Made with [Cursor](https://cursor.com)