### PR TITLE
fix(ci): authenticate relayed PR checkout setup commands

### DIFF
--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -37,7 +37,7 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 
 ### Relayed GitHub context
 
-Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends `git fetch` / `git checkout` commands to `resolved-setup-commands-json`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
+Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends authenticated PR checkout setup commands (`gh auth setup-git`, then `git fetch` / `git checkout`) to `resolved-setup-commands-json`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
 
 ```yaml
   resolve-apm-assets:

--- a/scripts/ingress_github_context.py
+++ b/scripts/ingress_github_context.py
@@ -203,6 +203,8 @@ def build_relayed_setup_commands(ctx: RelayedGitHubContext) -> list[str]:
     pr_number = ctx.pull_request_number
     return [
         "set -euo pipefail",
+        ': "${GH_TOKEN:=${GITHUB_TOKEN:?GitHub token required for relayed PR checkout}}"',
+        "gh auth setup-git",
         f"git fetch origin {shlex.quote(f'pull/{pr_number}/head:{ref}')}",
         f"git checkout {shlex.quote(ref)}",
     ]

--- a/tests/test_ingress_github_context.py
+++ b/tests/test_ingress_github_context.py
@@ -72,7 +72,10 @@ def test_apply_relayed_context_prepends_instructions_and_checkout() -> None:
         "Platform rules"
     )
     assert setup[0] == "set -euo pipefail"
-    assert "pull/7/head:feature/test" in setup[1]
+    assert setup[1].startswith(': "${GH_TOKEN:=${GITHUB_TOKEN')
+    assert setup[2] == "gh auth setup-git"
+    assert "pull/7/head:feature/test" in setup[3]
+    assert setup[4] == "git checkout feature/test"
     assert setup[-1] == "npm ci"
 
 


### PR DESCRIPTION
## Summary

- Add `gh auth setup-git` (using `GH_TOKEN` or `GITHUB_TOKEN`) before relayed PR `git fetch` / `git checkout` setup commands, fixing `fatal: could not read Username for 'https://github.com'` in gh-aw runs.
- Builds on #1119 (relayed ingress context), which is already on `main`.

## Test plan

- [x] `python3 -m pytest tests/test_ingress_github_context.py -v`
- [ ] Verify a relayed PR workflow run checks out the PR head branch successfully in CI