### PR TITLE
fix(ingress): avoid fetch refspec into checked-out PR branch

### DIFF
--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -37,7 +37,7 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 
 ### Relayed GitHub context
 
-Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends `git fetch` / `git checkout` commands to `resolved-setup-commands-json`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
+Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends authenticated PR checkout setup commands (`gh auth setup-git`, then `git fetch` / `git checkout`) to `resolved-setup-commands-json`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
 
 ```yaml
   resolve-apm-assets:

--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -37,7 +37,7 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 
 ### Relayed GitHub context
 
-Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends authenticated PR checkout setup commands (`gh auth setup-git`, then `git fetch` / `git checkout`) to `resolved-setup-commands-json`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
+Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends authenticated PR checkout setup commands (`gh auth setup-git`, then `git fetch pull/N/head` and `git checkout -B <head-ref> FETCH_HEAD`) to `resolved-setup-commands-json`. Fetching into the checked-out branch ref fails in CI when the runner already has the PR branch checked out; `checkout -B` resets safely from `FETCH_HEAD`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
 
 ```yaml
   resolve-apm-assets:

--- a/scripts/ingress_github_context.py
+++ b/scripts/ingress_github_context.py
@@ -203,6 +203,8 @@ def build_relayed_setup_commands(ctx: RelayedGitHubContext) -> list[str]:
     pr_number = ctx.pull_request_number
     return [
         "set -euo pipefail",
+        ': "${GH_TOKEN:=${GITHUB_TOKEN:?GitHub token required for relayed PR checkout}}"',
+        "gh auth setup-git",
         f"git fetch origin {shlex.quote(f'pull/{pr_number}/head:{ref}')}",
         f"git checkout {shlex.quote(ref)}",
     ]

--- a/scripts/ingress_github_context.py
+++ b/scripts/ingress_github_context.py
@@ -205,8 +205,9 @@ def build_relayed_setup_commands(ctx: RelayedGitHubContext) -> list[str]:
         "set -euo pipefail",
         ': "${GH_TOKEN:=${GITHUB_TOKEN:?GitHub token required for relayed PR checkout}}"',
         "gh auth setup-git",
-        f"git fetch origin {shlex.quote(f'pull/{pr_number}/head:{ref}')}",
-        f"git checkout {shlex.quote(ref)}",
+        # Fetch to FETCH_HEAD only: refspec updates to the checked-out branch fail in CI.
+        f"git fetch origin {shlex.quote(f'pull/{pr_number}/head')}",
+        f"git checkout -B {shlex.quote(ref)} FETCH_HEAD",
     ]
 
 

--- a/tests/test_ingress_github_context.py
+++ b/tests/test_ingress_github_context.py
@@ -74,9 +74,27 @@ def test_apply_relayed_context_prepends_instructions_and_checkout() -> None:
     assert setup[0] == "set -euo pipefail"
     assert setup[1].startswith(': "${GH_TOKEN:=${GITHUB_TOKEN')
     assert setup[2] == "gh auth setup-git"
-    assert "pull/7/head:feature/test" in setup[3]
-    assert setup[4] == "git checkout feature/test"
+    assert setup[3] == "git fetch origin pull/7/head"
+    assert setup[4] == "git checkout -B feature/test FETCH_HEAD"
     assert setup[-1] == "npm ci"
+
+
+def test_build_relayed_setup_commands_uses_fetch_head_for_checked_out_branch() -> None:
+    ctx = igc.RelayedGitHubContext(
+        event_name="pull_request",
+        event_action="synchronize",
+        pull_request_number=55,
+        pull_request_title="Bump terragrunt",
+        pull_request_head_ref="updatecli_main_terragrunt/version",
+        pull_request_head_sha="abc123",
+        issue_number=None,
+        comment_id=None,
+        discussion_number=None,
+    )
+    setup = igc.build_relayed_setup_commands(ctx)
+    assert setup[3] == "git fetch origin pull/55/head"
+    assert setup[4] == "git checkout -B updatecli_main_terragrunt/version FETCH_HEAD"
+    assert ":updatecli_main_terragrunt/version" not in setup[3]
 
 
 def test_apply_relayed_context_noop_without_target() -> None:

--- a/tests/test_ingress_github_context.py
+++ b/tests/test_ingress_github_context.py
@@ -72,7 +72,10 @@ def test_apply_relayed_context_prepends_instructions_and_checkout() -> None:
         "Platform rules"
     )
     assert setup[0] == "set -euo pipefail"
-    assert "pull/7/head:feature/test" in setup[1]
+    assert setup[1].startswith(': "${GH_TOKEN:=${GITHUB_TOKEN')
+    assert setup[2] == "gh auth setup-git"
+    assert "pull/7/head:feature/test" in setup[3]
+    assert setup[4] == "git checkout feature/test"
     assert setup[-1] == "npm ci"
 
 


### PR DESCRIPTION
## Summary

- Fix relayed PR checkout setup commands that failed in CI with `fatal: refusing to fetch into branch ... checked out` when the runner already had the PR head branch checked out (for example Updatecli branches like `updatecli_main_terragrunt/version`).
- Replace `git fetch origin pull/N/head:branch` with `git fetch origin pull/N/head` followed by `git checkout -B branch FETCH_HEAD`, which safely resets the branch from the fetched PR head.
- Document the updated checkout sequence in `aw-resolve-apm-assets.md` and add a unit test for slash-containing branch names.

## Test plan

- [x] `python3 -m pytest tests/test_ingress_github_context.py -v` (6 passed)
- [ ] Re-run the failing agentic workflow on a PR whose head branch is already checked out on the runner

Related issue: https://github.com/elastic/observability-robots/issues/4595
