### PR TITLE
fix(ingress): prepare relayed github.event for workflow_dispatch size limits

### DIFF
--- a/.cursor/rules/distribute-client-workflow-protected.mdc
+++ b/.cursor/rules/distribute-client-workflow-protected.mdc
@@ -1,0 +1,42 @@
+---
+description: Client entrypoints — edit remote-workflow-template only; do not edit distributed copies under .github/workflows/.
+alwaysApply: true
+---
+
+# distribute-client-workflow — where to edit client workflows
+
+[`distribute-client-workflow.yml`](.github/workflows/distribute-client-workflow.yml) installs files from [`.github/remote-workflow-template/<org-key>/`](.github/remote-workflow-template/) into each target repository at **`.github/workflows/`** (see [docs/operations/distribute-client-workflow.md](docs/operations/distribute-client-workflow.md)).
+
+## Edit here (source of truth)
+
+When client trigger/entrypoint workflows need to change, edit **only** under:
+
+- `.github/remote-workflow-template/obs/.github/workflows/` — e.g. `trigger-oblt-aw.yml`, `oblt-aw.yml`
+- `.github/remote-workflow-template/docs/.github/workflows/` — e.g. `trigger-docs-aw.yml`, `docs-aw.yml`
+
+Do **not** add per-workflow `trigger-oblt-aw-*.yml` files; extend the unified triggers in that tree.
+
+## Do not edit (distributed copies)
+
+**Do not** create, edit, delete, or rename the **installed copies** under **`.github/workflows/`** that come from the template, including in this repository when they are distribution targets (e.g. [`trigger-oblt-aw.yml`](.github/workflows/trigger-oblt-aw.yml), [`oblt-aw.yml`](.github/workflows/oblt-aw.yml)).
+
+Those paths are updated **only** when `distribute-client-workflow` syncs from `remote-workflow-template` (install PRs on consumer repos). Hand-editing them causes drift from the template and the next distribution may overwrite or conflict.
+
+| Template (edit) | Distributed destination (preserve) |
+|-----------------|-------------------------------------|
+| `remote-workflow-template/obs/.github/workflows/trigger-oblt-aw.yml` | `.github/workflows/trigger-oblt-aw.yml` |
+| `remote-workflow-template/obs/.github/workflows/oblt-aw.yml` | `.github/workflows/oblt-aw.yml` |
+| `remote-workflow-template/docs/.github/workflows/trigger-docs-aw.yml` | `.github/workflows/trigger-docs-aw.yml` |
+| `remote-workflow-template/docs/.github/workflows/docs-aw.yml` | `.github/workflows/docs-aw.yml` |
+
+## Control-plane workflows (safe to edit)
+
+Reusable ingress, routes, CI, and platform workflows under `.github/workflows/` that are **not** distribution template outputs remain in this repo, for example:
+
+- `oblt-aw-ingress.yml`, `docs-aw-ingress.yml`, `oblt-aw-*.yml`, `docs-aw-*.yml`, `aw-prelude.yml`, `aw-resolve-apm-assets.yml`, `distribute-client-workflow.yml`, `ci.yml`, etc.
+
+Consumer repos call these via `workflow_call` from `elastic/oblt-aw`; they are not installed from `remote-workflow-template`.
+
+## After template changes
+
+Tell the user that consumers (and this repo if listed in `config/*/active-repositories.json`) need a **distribution run** or sync PR for `.github/workflows/` copies to match the template.

--- a/.cursor/rules/protected-oblt-aw-workflow.mdc
+++ b/.cursor/rules/protected-oblt-aw-workflow.mdc
@@ -1,14 +1,15 @@
 ---
-description: Client workflows — `.github/remote-workflow-template/obs/`
+description: Client workflows — edit remote-workflow-template; preserve distributed .github/workflows/ copies.
 alwaysApply: true
 ---
 
-# Client workflows — `.github/remote-workflow-template/obs/`
+# Client workflows — template vs distributed copies
 
-**Do not** add per-workflow `trigger-oblt-aw-*.yml` client entrypoints.
+See **[distribute-client-workflow-protected.mdc](distribute-client-workflow-protected.mdc)**.
 
-**Where to change consumer entrypoints:** [`.github/remote-workflow-template/obs/.github/workflows/trigger-oblt-aw.yml`](.github/remote-workflow-template/obs/.github/workflows/trigger-oblt-aw.yml) and [`.github/remote-workflow-template/obs/.github/workflows/oblt-aw.yml`](.github/remote-workflow-template/obs/.github/workflows/oblt-aw.yml) only. Distribution installs that tree into target repositories.
+- **Edit:** `.github/remote-workflow-template/<org-key>/.github/workflows/` (e.g. `trigger-oblt-aw.yml`, `oblt-aw.yml`).
+- **Do not edit:** matching files under **`.github/workflows/`** in distribution targets — updated only via [`distribute-client-workflow.yml`](.github/workflows/distribute-client-workflow.yml).
 
-**Control-plane reusables** live under `.github/workflows/oblt-aw-*.yml` (ingress: `oblt-aw-ingress.yml`; shared prelude: `aw-prelude.yml`). **Do not** edit consumer copies under target repos from this repository except via distribution.
+**Control-plane** reusables (`oblt-aw-ingress.yml`, `oblt-aw-*.yml`, `docs-aw-*.yml`, …) live under `.github/workflows/` and are not part of that template install.
 
-**Docs:** [docs/workflows/oblt-aw-client-template.md](docs/workflows/oblt-aw-client-template.md), [CONTRIBUTING.md](CONTRIBUTING.md).
+**Docs:** [docs/workflows/oblt-aw-client-template.md](docs/workflows/oblt-aw-client-template.md), [docs/operations/distribute-client-workflow.md](docs/operations/distribute-client-workflow.md), [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/.github/actions/prepare-relayed-github-event/action.yml
+++ b/.github/actions/prepare-relayed-github-event/action.yml
@@ -19,7 +19,7 @@ runs:
         set -euo pipefail
         mode_file="$(mktemp)"
         export RELAY_PREPARE_MODE_OUTPUT="$mode_file"
-        payload="$(python3 "${{ github.action_path }}/../../scripts/prepare_relayed_github_event.py")"
+        payload="$(python3 "${{ github.action_path }}/../../../scripts/prepare_relayed_github_event.py")"
         relay_mode="$(cat "$mode_file")"
         rm -f "$mode_file"
         {

--- a/.github/actions/prepare-relayed-github-event/action.yml
+++ b/.github/actions/prepare-relayed-github-event/action.yml
@@ -1,0 +1,30 @@
+name: Prepare relayed GitHub event
+description: >-
+  Passthrough, slim, or truncate github.event JSON for workflow_dispatch relay
+  inputs when the webhook exceeds GitHub size limits. See docs/workflows/relayed-event-payload.md.
+outputs:
+  payload-json:
+    description: JSON for event-payload-json / ingress-event-payload-json
+    value: ${{ steps.prepare.outputs.payload-json }}
+  relay-mode:
+    description: passthrough, slim, or truncated
+    value: ${{ steps.prepare.outputs.relay-mode }}
+runs:
+  using: composite
+  steps:
+    - name: Prepare github.event for dispatch relay
+      id: prepare
+      shell: bash
+      run: |
+        set -euo pipefail
+        mode_file="$(mktemp)"
+        export RELAY_PREPARE_MODE_OUTPUT="$mode_file"
+        payload="$(python3 "${{ github.action_path }}/../../scripts/prepare_relayed_github_event.py")"
+        relay_mode="$(cat "$mode_file")"
+        rm -f "$mode_file"
+        {
+          echo 'payload-json<<EOF'
+          printf '%s' "$payload"
+          echo 'EOF'
+          echo "relay-mode=$relay_mode"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw.yml
@@ -44,6 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Prepare github.event for workflow_dispatch relay
+        id: prepare-relayed-event
+        uses: elastic/oblt-aw/.github/actions/prepare-relayed-github-event@main # ratchet:exclude
+
       - name: Dispatch docs-aw entrypoint
         id: dispatch
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
@@ -55,7 +59,7 @@ jobs:
               "trigger-source": ${{ toJSON(github.workflow) }},
               "event-name": ${{ toJSON(github.event_name) }},
               "event-action": ${{ toJSON(github.event.action || '') }},
-              "event-payload-json": ${{ toJSON(toJSON(github.event)) }},
+              "event-payload-json": ${{ toJSON(steps.prepare-relayed-event.outputs.payload-json) }},
               "caller-ref": ${{ toJSON(github.ref) }},
               "caller-sha": ${{ toJSON(github.sha) }},
               "caller-run-id": ${{ toJSON(github.run_id) }}

--- a/.github/remote-workflow-template/obs/.github/workflows/trigger-oblt-aw.yml
+++ b/.github/remote-workflow-template/obs/.github/workflows/trigger-oblt-aw.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Prepare github.event for workflow_dispatch relay
+        id: prepare-relayed-event
+        uses: elastic/oblt-aw/.github/actions/prepare-relayed-github-event@main # ratchet:exclude
+
       - name: Dispatch oblt-aw entrypoint
         id: dispatch
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
@@ -38,7 +42,7 @@ jobs:
               "trigger-source": ${{ toJSON(github.workflow) }},
               "event-name": ${{ toJSON(github.event_name) }},
               "event-action": ${{ toJSON(github.event.action || '') }},
-              "event-payload-json": ${{ toJSON(toJSON(github.event)) }},
+              "event-payload-json": ${{ toJSON(steps.prepare-relayed-event.outputs.payload-json) }},
               "caller-ref": ${{ toJSON(github.ref) }},
               "caller-sha": ${{ toJSON(github.sha) }},
               "caller-run-id": ${{ toJSON(github.run_id) }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,11 @@
 
 ## Client entrypoint changes
 
-Use **[`.github/remote-workflow-template/`](.github/remote-workflow-template/)** as the source for distributed client workflows (for example `obs/.github/workflows/trigger-oblt-aw.yml` and `obs/.github/workflows/oblt-aw.yml`, plus `docs/.github/workflows/trigger-docs-aw.yml` and `docs/.github/workflows/docs-aw.yml`). See [docs/workflows/oblt-aw-client-template.md](docs/workflows/oblt-aw-client-template.md), [docs/workflows/docs-aw-client-template.md](docs/workflows/docs-aw-client-template.md), and [CONTRIBUTING.md](CONTRIBUTING.md).
+Edit client triggers and entrypoints **only** under [`.github/remote-workflow-template/`](.github/remote-workflow-template/) (for example `obs/.github/workflows/trigger-oblt-aw.yml` and `oblt-aw.yml`). **Do not** hand-edit the distributed copies under [`.github/workflows/`](.github/workflows/) (`trigger-oblt-aw.yml`, `oblt-aw.yml`, docs equivalents)—those are installed by [`distribute-client-workflow.yml`](.github/workflows/distribute-client-workflow.yml). See [.cursor/rules/distribute-client-workflow-protected.mdc](.cursor/rules/distribute-client-workflow-protected.mdc).
+
+Ingress and route reusables (`oblt-aw-ingress.yml`, `oblt-aw-*.yml`, `docs-aw-*.yml`, …) are control-plane workflows in `.github/workflows/` and are not distribution template outputs.
+
+See [docs/workflows/oblt-aw-client-template.md](docs/workflows/oblt-aw-client-template.md), [docs/workflows/docs-aw-client-template.md](docs/workflows/docs-aw-client-template.md), and [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Consumer Observability repos use **`trigger-oblt-aw.yml`** (events) → **`oblt-aw.yml`** (`workflow_dispatch`) → **`oblt-aw-ingress.yml`** (routing).
 

--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -37,7 +37,7 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 
 ### Relayed GitHub context
 
-Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends `git fetch` / `git checkout` commands to `resolved-setup-commands-json`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
+Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends authenticated PR checkout setup commands (`gh auth setup-git`, then `git fetch` / `git checkout`) to `resolved-setup-commands-json`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
 
 ```yaml
   resolve-apm-assets:

--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -37,7 +37,7 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 
 ### Relayed GitHub context
 
-Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends authenticated PR checkout setup commands (`gh auth setup-git`, then `git fetch` / `git checkout`) to `resolved-setup-commands-json`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
+Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends authenticated PR checkout setup commands (`gh auth setup-git`, then `git fetch pull/N/head` and `git checkout -B <head-ref> FETCH_HEAD`) to `resolved-setup-commands-json`. Fetching into the checked-out branch ref fails in CI when the runner already has the PR branch checked out; `checkout -B` resets safely from `FETCH_HEAD`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
 
 ```yaml
   resolve-apm-assets:

--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -22,7 +22,7 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 | `install-apm-packages` | boolean | `true` | Run `apm install` when `apm.yml` is present |
 | `ingress-event-name` | string | `""` | Relayed `github.event_name` from ingress (prepended gh-aw context block) |
 | `ingress-event-action` | string | `""` | Relayed `github.event.action` from ingress |
-| `ingress-event-payload-json` | string | `""` | Relayed `github.event` JSON from ingress; drives authoritative PR/issue numbers in agent prompts and optional PR checkout setup commands |
+| `ingress-event-payload-json` | string | `""` | Prepared relayed `github.event` JSON from ingress ([relayed-event-payload.md](relayed-event-payload.md)); drives authoritative PR/issue numbers in agent prompts and optional PR checkout setup commands |
 
 ### Outputs
 
@@ -37,7 +37,7 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 
 ### Relayed GitHub context
 
-Consumer entrypoints relay the original webhook payload through ingress (`ingress-event-payload-json`). Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends authenticated PR checkout setup commands (`gh auth setup-git`, then `git fetch pull/N/head` and `git checkout -B <head-ref> FETCH_HEAD`) to `resolved-setup-commands-json`. Fetching into the checked-out branch ref fails in CI when the runner already has the PR branch checked out; `checkout -B` resets safely from `FETCH_HEAD`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
+Consumer entrypoints relay a prepared webhook payload through ingress (`ingress-event-payload-json`), built by `prepare-relayed-github-event` (passthrough, slim, or truncate) so `workflow_dispatch` inputs stay within GitHub size limits. Upstream `gh-aw-*` lock files still read native `github.event`, which is empty under the `workflow_dispatch` entrypoint model. This workflow injects an authoritative **Relayed ingress context** block at the top of `resolved-additional-instructions` and, for pull requests, prepends authenticated PR checkout setup commands (`gh auth setup-git`, then `git fetch pull/N/head` and `git checkout -B <head-ref> FETCH_HEAD`) to `resolved-setup-commands-json`. Fetching into the checked-out branch ref fails in CI when the runner already has the PR branch checked out; `checkout -B` resets safely from `FETCH_HEAD`. Callers should pass `setup-commands: ${{ join(fromJSON(needs.<resolve-job>.outputs.resolved-setup-commands-json), ' && ') }}` to `gh-aw-*` jobs that accept the input.
 
 ```yaml
   resolve-apm-assets:
@@ -72,3 +72,4 @@ Examples with upstream gates: [oblt-aw-automerge.yml](../../.github/workflows/ob
 - [Agentic Workflow Prelude](aw-prelude.md)
 - [scripts/resolve_apm_agentic_assets.py](../../scripts/resolve_apm_agentic_assets.py)
 - [scripts/ingress_github_context.py](../../scripts/ingress_github_context.py)
+- [relayed-event-payload.md](relayed-event-payload.md)

--- a/docs/workflows/docs-aw-ingress.md
+++ b/docs/workflows/docs-aw-ingress.md
@@ -16,7 +16,7 @@ Route ids and workflow files are declared in [`config/docs/workflow-registry.jso
 | `trigger-source` | yes | Client trigger workflow basename |
 | `ingress-event-name` | yes | Original `github.event_name` |
 | `ingress-event-action` | no | Original `github.event.action` |
-| `ingress-event-payload-json` | yes | `toJSON(github.event)` from the trigger |
+| `ingress-event-payload-json` | yes | Prepared `github.event` JSON from the trigger ([relayed-event-payload.md](relayed-event-payload.md)) |
 | `caller-ref` | yes | Original `github.ref` |
 | `caller-sha` | yes | Original `github.sha` |
 | `caller-run-id` | yes | Original `github.run_id` |

--- a/docs/workflows/oblt-aw-client-template.md
+++ b/docs/workflows/oblt-aw-client-template.md
@@ -52,7 +52,7 @@ flowchart TB
 | `trigger-source` | `github.workflow` |
 | `event-name` | `github.event_name` |
 | `event-action` | `github.event.action` |
-| `event-payload-json` | `toJSON(github.event)` |
+| `event-payload-json` | Prepared `github.event` JSON via `elastic/oblt-aw/.github/actions/prepare-relayed-github-event` (passthrough when small; otherwise slim/truncate — see [relayed-event-payload.md](relayed-event-payload.md)) |
 | `caller-ref` | `github.ref` |
 | `caller-sha` | `github.sha` |
 | `caller-run-id` | `github.run_id` |

--- a/docs/workflows/oblt-aw-ingress.md
+++ b/docs/workflows/oblt-aw-ingress.md
@@ -16,7 +16,7 @@ Route ids and workflow files are declared in [`config/obs/workflow-registry.json
 | `trigger-source` | yes | Client trigger workflow basename |
 | `ingress-event-name` | yes | Original `github.event_name` |
 | `ingress-event-action` | no | Original `github.event.action` |
-| `ingress-event-payload-json` | yes | `toJSON(github.event)` from the trigger |
+| `ingress-event-payload-json` | yes | Prepared `github.event` JSON from the trigger ([relayed-event-payload.md](relayed-event-payload.md)) |
 | `caller-ref` | yes | Original `github.ref` |
 | `caller-sha` | yes | Original `github.sha` |
 | `caller-run-id` | yes | Original `github.run_id` |

--- a/docs/workflows/relayed-event-payload.md
+++ b/docs/workflows/relayed-event-payload.md
@@ -29,7 +29,7 @@ These paths are the **contract** for ingress routing, wrapper `if:` expressions,
 | `context` | Buildkite status routing (`buildkite` in context) |
 | `sha` | Status events (optional) |
 | `description` | Status events (optional; truncatable) |
-| `target_url` | Status events (optional; truncatable) |
+| `target_url` | Status events (optional; preserved in slim, not truncated) |
 
 ### `pull_request`
 

--- a/docs/workflows/relayed-event-payload.md
+++ b/docs/workflows/relayed-event-payload.md
@@ -12,7 +12,7 @@ Preparation is implemented in [scripts/ingress_github_context.py](../../scripts/
 | `slim` | Full event exceeds budget; slimmed fits | Only the attributes listed below (bloat removed) |
 | `truncated` | Slimmed still exceeds budget | Slim shape; long **non-routing** strings shortened (see truncation) |
 
-Budget defaults to 62,000 characters for the relay JSON string so sibling dispatch inputs (`trigger-source`, `event-name`, `caller-ref`, etc.) stay within the documented 65,535-character combined `workflow_dispatch` inputs payload.
+Budget defaults to **63,487** characters for the relay JSON string (`RELAY_EVENT_JSON_MAX_CHARS` in [scripts/ingress_github_context.py](../../scripts/ingress_github_context.py)): GitHub’s documented **65,535**-character combined `workflow_dispatch` inputs limit minus **2,048** reserved for sibling dispatch inputs (`trigger-source`, `event-name`, `caller-ref`, and related metadata).
 
 ## Attributes used by control-plane workflows
 

--- a/docs/workflows/relayed-event-payload.md
+++ b/docs/workflows/relayed-event-payload.md
@@ -1,0 +1,108 @@
+# Relayed `github.event` payload contract
+
+Consumer triggers relay the original webhook through `event-payload-json` → `ingress-event-payload-json`. The relay must stay within GitHub `workflow_dispatch` input size limits (see [workflow syntax — `on.workflow_dispatch.inputs`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_dispatchinputs)).
+
+Preparation is implemented in [scripts/ingress_github_context.py](../../scripts/ingress_github_context.py) (`prepare_relayed_github_event_json`) and invoked from [`.github/actions/prepare-relayed-github-event`](../../.github/actions/prepare-relayed-github-event/action.yml) on each trigger run.
+
+## Preparation modes
+
+| Mode | When | What is sent |
+|------|------|----------------|
+| `passthrough` | Serialized full `github.event` ≤ budget | Unmodified webhook JSON |
+| `slim` | Full event exceeds budget; slimmed fits | Only the attributes listed below (bloat removed) |
+| `truncated` | Slimmed still exceeds budget | Slim shape; long **non-routing** strings shortened (see truncation) |
+
+Budget defaults to 62,000 characters for the relay JSON string so sibling dispatch inputs (`trigger-source`, `event-name`, `caller-ref`, etc.) stay within the documented 65,535-character combined `workflow_dispatch` inputs payload.
+
+## Attributes used by control-plane workflows
+
+These paths are the **contract** for ingress routing, wrapper `if:` expressions, scripts, and relayed agent context. They are preserved in `slim` mode.
+
+### Top-level
+
+| Path | Used for |
+|------|----------|
+| `action` | Relayed event action; agent context |
+| `inputs.issue_number` | Docs manual `workflow_dispatch` (issue menu) |
+| `inputs.pull_request_number` | Docs manual `workflow_dispatch` (PR menu) |
+| `state` | Buildkite status routing (`failure`) |
+| `context` | Buildkite status routing (`buildkite` in context) |
+| `sha` | Status events (optional) |
+| `description` | Status events (optional; truncatable) |
+| `target_url` | Status events (optional; truncatable) |
+
+### `pull_request`
+
+| Path | Used for |
+|------|----------|
+| `pull_request.number` | Ingress routes, automerge, dependency-review, docs PR menu/collect |
+| `pull_request.title` | Agent relayed context (truncatable) |
+| `pull_request.head.ref` | PR checkout setup commands |
+| `pull_request.head.sha` | Agent relayed context |
+| `pull_request.user.login` | Ingress author allow-list gates |
+| `pull_request.labels[].name` | Ingress label-based routing |
+
+### `issue`
+
+| Path | Used for |
+|------|----------|
+| `issue.number` | Ingress, security/triage, docs menus, PR-as-issue routes |
+| `issue.title` | Agent relayed context (truncatable) |
+| `issue.pull_request` | Distinguish issue vs PR (`null` vs `{}` / object) |
+| `issue.labels[].name` | Ingress label and fixer/triage routing |
+
+### `comment`
+
+| Path | Used for |
+|------|----------|
+| `comment.id` | Agent relayed context |
+| `comment.body` | `/ai` / `/ai implement` routing; docs menu marker `contains` (truncatable with prefix/suffix preserved) |
+| `comment.author_association` | Author allow-list for issue comments |
+| `comment.user.login` | Docs bot menu detection (`github-actions[bot]`) |
+
+### `label` (issues `labeled` events)
+
+| Path | Used for |
+|------|----------|
+| `label.name` | Security / res-not-accessible / fix-ready routing |
+
+### `changes` (`issue_comment` edited)
+
+| Path | Used for |
+|------|----------|
+| `changes.body.from` | Docs menu checkbox diff (`evaluate-trigger.js`) (truncatable) |
+
+### `workflow_run`
+
+| Path | Used for |
+|------|----------|
+| `workflow_run.id` | Docs PR AI menu concurrency / artifact download |
+| `workflow_run.conclusion` | Docs ingress / PR menu (`success`) |
+| `workflow_run.event` | Docs ingress (`pull_request`) |
+
+### `discussion`
+
+| Path | Used for |
+|------|----------|
+| `discussion.number` | Agent relayed context (when present) |
+
+## Removed in `slim` mode (not used in workflows)
+
+Examples: `pull_request.files`, `pull_request.commits`, `pull_request.body`, bulk repository metadata, check suites, reviews, and other webhook bloat. Agents must load these via GitHub MCP (see relayed context instructions in `ingress_github_context.py`).
+
+## Truncation ( `truncated` mode only)
+
+Applied only after `slim` when the payload is still over budget. Order:
+
+1. `changes.body.from` — cap length (menu state is usually at the start of the body)
+2. `comment.body` — cap length while preserving start and end segments for `/ai…` prefixes and HTML menu markers
+3. `pull_request.title`, `issue.title` — cap length
+4. `description` — cap length
+
+Truncation does **not** remove routing-critical scalars (numbers, label names, `author_association`, `user.login`, `head.ref`, `head.sha`, etc.).
+
+## References
+
+- [oblt-aw ingress](oblt-aw-ingress.md) — `ingress-event-payload-json` input
+- [aw-resolve-apm-assets](aw-resolve-apm-assets.md) — relayed context in agent prompts
+- [oblt-aw client template](oblt-aw-client-template.md) — trigger relay

--- a/scripts/ingress_github_context.py
+++ b/scripts/ingress_github_context.py
@@ -203,6 +203,8 @@ def build_relayed_setup_commands(ctx: RelayedGitHubContext) -> list[str]:
     pr_number = ctx.pull_request_number
     return [
         "set -euo pipefail",
+        ': "${GH_TOKEN:=${GITHUB_TOKEN:?GitHub token required for relayed PR checkout}}"',
+        "gh auth setup-git",
         f"git fetch origin {shlex.quote(f'pull/{pr_number}/head:{ref}')}",
         f"git checkout {shlex.quote(ref)}",
     ]

--- a/scripts/ingress_github_context.py
+++ b/scripts/ingress_github_context.py
@@ -14,10 +14,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Build gh-aw prompt and setup overrides from relayed ingress event JSON."""
+"""Build gh-aw prompt and setup overrides from relayed ingress event JSON.
+
+Relay payload contract (attributes used by ingress and wrappers):
+docs/workflows/relayed-event-payload.md
+"""
 
 from __future__ import annotations
 
+import copy
 import json
 import shlex
 from dataclasses import dataclass
@@ -65,6 +70,243 @@ def _optional_str(value: Any) -> str | None:
         stripped = value.strip()
         return stripped or None
     return None
+
+
+# GitHub documents a 65,535-character maximum payload for workflow_dispatch inputs (combined).
+# See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_dispatchinputs
+WORKFLOW_DISPATCH_INPUT_MAX_CHARS = 65_535
+# Reserve space for sibling dispatch inputs (trigger-source, event-name, caller-ref, …).
+DISPATCH_SIBLING_INPUTS_RESERVED_CHARS = 2048
+RELAY_EVENT_JSON_MAX_CHARS = (
+    WORKFLOW_DISPATCH_INPUT_MAX_CHARS - DISPATCH_SIBLING_INPUTS_RESERVED_CHARS
+)
+
+# Truncation caps (truncated mode only). See docs/workflows/relayed-event-payload.md.
+TRUNCATE_COMMENT_BODY_MAX_CHARS = 8192
+TRUNCATE_COMMENT_BODY_SUFFIX_CHARS = 512
+TRUNCATE_CHANGES_BODY_FROM_MAX_CHARS = 8192
+TRUNCATE_TITLE_MAX_CHARS = 512
+TRUNCATE_DESCRIPTION_MAX_CHARS = 512
+
+RELAY_PREPARE_MODE_PASSTHROUGH = "passthrough"
+RELAY_PREPARE_MODE_SLIM = "slim"
+RELAY_PREPARE_MODE_TRUNCATED = "truncated"
+
+
+def _slim_label_list(labels: Any) -> list[dict[str, str]] | None:
+    if not isinstance(labels, list):
+        return None
+    out: list[dict[str, str]] = []
+    for item in labels:
+        if isinstance(item, dict):
+            name = _optional_str(item.get("name"))
+            if name:
+                out.append({"name": name})
+    return out or None
+
+
+def slim_relayed_github_event(event: dict[str, Any]) -> dict[str, Any]:
+    """Return the minimal github.event fields required by ingress routing and agents."""
+    slim: dict[str, Any] = {}
+
+    if action := _optional_str(event.get("action")):
+        slim["action"] = action
+
+    inputs = event.get("inputs")
+    if isinstance(inputs, dict):
+        slim_inputs: dict[str, Any] = {}
+        for key in ("issue_number", "pull_request_number"):
+            if key in inputs:
+                slim_inputs[key] = inputs[key]
+        if slim_inputs:
+            slim["inputs"] = slim_inputs
+
+    for key in ("state", "context", "description", "target_url", "sha"):
+        if key in event and event[key] is not None:
+            slim[key] = event[key]
+
+    changes = event.get("changes")
+    if isinstance(changes, dict):
+        body_change = changes.get("body")
+        if isinstance(body_change, dict) and "from" in body_change:
+            slim["changes"] = {"body": {"from": body_change["from"]}}
+
+    pull_request = event.get("pull_request")
+    if isinstance(pull_request, dict):
+        slim_pr: dict[str, Any] = {}
+        if number := _positive_int(pull_request.get("number")):
+            slim_pr["number"] = number
+        if title := _optional_str(pull_request.get("title")):
+            slim_pr["title"] = title
+        user = pull_request.get("user")
+        if isinstance(user, dict):
+            login = _optional_str(user.get("login"))
+            if login:
+                slim_pr["user"] = {"login": login}
+        head = pull_request.get("head")
+        if isinstance(head, dict):
+            slim_head: dict[str, str] = {}
+            if ref := _optional_str(head.get("ref")):
+                slim_head["ref"] = ref
+            if sha := _optional_str(head.get("sha")):
+                slim_head["sha"] = sha
+            if slim_head:
+                slim_pr["head"] = slim_head
+        if labels := _slim_label_list(pull_request.get("labels")):
+            slim_pr["labels"] = labels
+        if slim_pr:
+            slim["pull_request"] = slim_pr
+
+    issue = event.get("issue")
+    if isinstance(issue, dict):
+        slim_issue: dict[str, Any] = {}
+        if number := _positive_int(issue.get("number")):
+            slim_issue["number"] = number
+        if title := _optional_str(issue.get("title")):
+            slim_issue["title"] = title
+        if issue.get("pull_request") is not None:
+            slim_issue["pull_request"] = {}
+        if labels := _slim_label_list(issue.get("labels")):
+            slim_issue["labels"] = labels
+        if slim_issue:
+            slim["issue"] = slim_issue
+
+    comment = event.get("comment")
+    if isinstance(comment, dict):
+        slim_comment: dict[str, Any] = {}
+        if comment_id := _positive_int(comment.get("id")):
+            slim_comment["id"] = comment_id
+        if isinstance(comment.get("body"), str):
+            slim_comment["body"] = comment["body"]
+        if assoc := _optional_str(comment.get("author_association")):
+            slim_comment["author_association"] = assoc
+        user = comment.get("user")
+        if isinstance(user, dict):
+            login = _optional_str(user.get("login"))
+            if login:
+                slim_comment["user"] = {"login": login}
+        if slim_comment:
+            slim["comment"] = slim_comment
+
+    label = event.get("label")
+    if isinstance(label, dict):
+        if name := _optional_str(label.get("name")):
+            slim["label"] = {"name": name}
+
+    discussion = event.get("discussion")
+    if isinstance(discussion, dict):
+        if number := _positive_int(discussion.get("number")):
+            slim["discussion"] = {"number": number}
+
+    workflow_run = event.get("workflow_run")
+    if isinstance(workflow_run, dict):
+        slim_wr: dict[str, Any] = {}
+        if run_id := _positive_int(workflow_run.get("id")):
+            slim_wr["id"] = run_id
+        if conclusion := _optional_str(workflow_run.get("conclusion")):
+            slim_wr["conclusion"] = conclusion
+        if wr_event := _optional_str(workflow_run.get("event")):
+            slim_wr["event"] = wr_event
+        if slim_wr:
+            slim["workflow_run"] = slim_wr
+
+    return slim
+
+
+def _relay_json_size(payload: dict[str, Any]) -> int:
+    return len(json.dumps(payload, separators=(",", ":")))
+
+
+def _truncate_text(
+    value: str,
+    max_chars: int,
+    *,
+    preserve_suffix_chars: int = 0,
+) -> str:
+    if len(value) <= max_chars:
+        return value
+    if preserve_suffix_chars > 0 and max_chars > preserve_suffix_chars + 32:
+        prefix_len = max_chars - preserve_suffix_chars - 3
+        return f"{value[:prefix_len]}...{value[-preserve_suffix_chars:]}"
+    return value[:max_chars]
+
+
+def truncate_relayed_github_event(event: dict[str, Any]) -> dict[str, Any]:
+    """Shorten long non-routing strings in an already-slimmed relay payload."""
+    truncated = copy.deepcopy(event)
+
+    changes = truncated.get("changes")
+    if isinstance(changes, dict):
+        body = changes.get("body")
+        if isinstance(body, dict) and isinstance(body.get("from"), str):
+            body["from"] = _truncate_text(
+                body["from"], TRUNCATE_CHANGES_BODY_FROM_MAX_CHARS
+            )
+
+    comment = truncated.get("comment")
+    if isinstance(comment, dict) and isinstance(comment.get("body"), str):
+        comment["body"] = _truncate_text(
+            comment["body"],
+            TRUNCATE_COMMENT_BODY_MAX_CHARS,
+            preserve_suffix_chars=TRUNCATE_COMMENT_BODY_SUFFIX_CHARS,
+        )
+
+    pull_request = truncated.get("pull_request")
+    if isinstance(pull_request, dict) and isinstance(pull_request.get("title"), str):
+        pull_request["title"] = _truncate_text(
+            pull_request["title"], TRUNCATE_TITLE_MAX_CHARS
+        )
+
+    issue = truncated.get("issue")
+    if isinstance(issue, dict) and isinstance(issue.get("title"), str):
+        issue["title"] = _truncate_text(issue["title"], TRUNCATE_TITLE_MAX_CHARS)
+
+    if isinstance(truncated.get("description"), str):
+        truncated["description"] = _truncate_text(
+            truncated["description"], TRUNCATE_DESCRIPTION_MAX_CHARS
+        )
+
+    return truncated
+
+
+def prepare_relayed_github_event(
+    event: dict[str, Any],
+    *,
+    max_chars: int = RELAY_EVENT_JSON_MAX_CHARS,
+) -> tuple[dict[str, Any], str]:
+    """Return relay payload and mode: passthrough, slim, or truncated."""
+    if _relay_json_size(event) <= max_chars:
+        return event, RELAY_PREPARE_MODE_PASSTHROUGH
+
+    slim = slim_relayed_github_event(event)
+    if _relay_json_size(slim) <= max_chars:
+        return slim, RELAY_PREPARE_MODE_SLIM
+
+    truncated = truncate_relayed_github_event(slim)
+    if _relay_json_size(truncated) <= max_chars:
+        return truncated, RELAY_PREPARE_MODE_TRUNCATED
+
+    msg = (
+        "relayed github.event JSON exceeds workflow_dispatch budget after slim and "
+        f"truncation ({_relay_json_size(truncated)} > {max_chars} chars)"
+    )
+    raise ValueError(msg)
+
+
+def prepare_relayed_github_event_json(
+    event: dict[str, Any],
+    *,
+    max_chars: int = RELAY_EVENT_JSON_MAX_CHARS,
+) -> tuple[str, str]:
+    """Serialize relay payload for event-payload-json; returns (json, mode)."""
+    payload, mode = prepare_relayed_github_event(event, max_chars=max_chars)
+    return json.dumps(payload, separators=(",", ":")), mode
+
+
+def slim_relayed_github_event_json(event: dict[str, Any]) -> str:
+    """Serialize after prepare (passthrough, slim, or truncated). Prefer prepare_* APIs."""
+    payload_json, _mode = prepare_relayed_github_event_json(event)
+    return payload_json
 
 
 def parse_relayed_ingress_payload(raw: str) -> dict[str, Any] | None:
@@ -188,8 +430,17 @@ def build_relayed_context_instructions(ctx: RelayedGitHubContext) -> str:
             "",
             "Rules:",
             "- Do not emit `missing_data` for pull request or issue numbers when relayed values above are present.",
-            "- Prefer GitHub MCP tools (`pull_request_read`, `issue_read`, and related methods) with these relayed numbers.",
             "- Treat relayed pull-request/issue numbers as the workflow target even when built-in context shows `#` or blank values.",
+            "- Do not rely on the built-in GitHub Actions `github.event` webhook object on this run (entrypoint is `workflow_dispatch`).",
+            "",
+            "GitHub data not guaranteed in the relay payload:",
+            "- The trigger may passthrough, slim, or truncate the webhook JSON to satisfy `workflow_dispatch` input size limits.",
+            "- Large or verbose webhook fields are omitted or shortened: PR/issue bodies, diffs, `files`/`commits` lists, reviews, checks, and similar bloat.",
+            "- Authoritative content must be loaded by the agent using GitHub MCP with the relayed numbers above, including when a field was truncated:",
+            "  - `pull_request_read` — PR metadata, description, files, reviews, commits, and CI-related context",
+            "  - `issue_read` — issue or PR-discussion body, labels, and timeline (use issue number; PRs are issues in the API)",
+            "  - Comment and review APIs — full comment bodies when the relay only preserved a prefix for routing",
+            "- Prefer MCP results over relayed JSON for any analysis, quoting, labels, or code changes.",
         ]
     )
     return "\n".join(lines)

--- a/scripts/ingress_github_context.py
+++ b/scripts/ingress_github_context.py
@@ -205,8 +205,9 @@ def build_relayed_setup_commands(ctx: RelayedGitHubContext) -> list[str]:
         "set -euo pipefail",
         ': "${GH_TOKEN:=${GITHUB_TOKEN:?GitHub token required for relayed PR checkout}}"',
         "gh auth setup-git",
-        f"git fetch origin {shlex.quote(f'pull/{pr_number}/head:{ref}')}",
-        f"git checkout {shlex.quote(ref)}",
+        # Fetch to FETCH_HEAD only: refspec updates to the checked-out branch fail in CI.
+        f"git fetch origin {shlex.quote(f'pull/{pr_number}/head')}",
+        f"git checkout -B {shlex.quote(ref)} FETCH_HEAD",
     ]
 
 

--- a/scripts/prepare_relayed_github_event.py
+++ b/scripts/prepare_relayed_github_event.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright 2026-2027 Elasticsearch B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""CLI: prepare github.event JSON for workflow_dispatch relay inputs."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from ingress_github_context import prepare_relayed_github_event_json
+
+
+def main() -> int:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        print("GITHUB_EVENT_PATH is required", file=sys.stderr)
+        return 1
+
+    event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    if not isinstance(event, dict):
+        print("github.event payload must be a JSON object", file=sys.stderr)
+        return 1
+
+    try:
+        payload_json, mode = prepare_relayed_github_event_json(event)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    mode_output = os.environ.get("RELAY_PREPARE_MODE_OUTPUT", "").strip()
+    if mode_output:
+        Path(mode_output).write_text(mode, encoding="utf-8")
+
+    print(payload_json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/slim_relayed_github_event.py
+++ b/scripts/slim_relayed_github_event.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright 2026-2027 Elasticsearch B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Deprecated CLI entrypoint; use prepare_relayed_github_event.py."""
+
+from prepare_relayed_github_event import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ingress_github_context.py
+++ b/tests/test_ingress_github_context.py
@@ -74,9 +74,27 @@ def test_apply_relayed_context_prepends_instructions_and_checkout() -> None:
     assert setup[0] == "set -euo pipefail"
     assert setup[1].startswith(': "${GH_TOKEN:=${GITHUB_TOKEN')
     assert setup[2] == "gh auth setup-git"
-    assert "pull/7/head:feature/test" in setup[3]
-    assert setup[4] == "git checkout feature/test"
+    assert setup[3] == "git fetch origin pull/7/head"
+    assert setup[4] == "git checkout -B feature/test FETCH_HEAD"
     assert setup[-1] == "npm ci"
+
+
+def test_build_relayed_setup_commands_uses_fetch_head_for_checked_out_branch() -> None:
+    ctx = igc.RelayedGitHubContext(
+        event_name="pull_request",
+        event_action="synchronize",
+        pull_request_number=55,
+        pull_request_title="Bump terragrunt",
+        pull_request_head_ref="updatecli_main_terragrunt/version",
+        pull_request_head_sha="abc123",
+        issue_number=None,
+        comment_id=None,
+        discussion_number=None,
+    )
+    setup = igc.build_relayed_setup_commands(ctx)
+    assert setup[3] == "git fetch origin pull/55/head"
+    assert setup[4] == "git checkout -B updatecli_main_terragrunt/version FETCH_HEAD"
+    assert ":updatecli_main_terragrunt/version" not in setup[3]
 
 
 def test_apply_relayed_context_noop_without_target() -> None:

--- a/tests/test_ingress_github_context.py
+++ b/tests/test_ingress_github_context.py
@@ -72,7 +72,10 @@ def test_apply_relayed_context_prepends_instructions_and_checkout() -> None:
         "Platform rules"
     )
     assert setup[0] == "set -euo pipefail"
-    assert "pull/7/head:feature/test" in setup[1]
+    assert setup[1].startswith(': "${GH_TOKEN:=${GITHUB_TOKEN')
+    assert setup[2] == "gh auth setup-git"
+    assert "pull/7/head:feature/test" in setup[3]
+    assert setup[4] == "git checkout feature/test"
     assert setup[-1] == "npm ci"
 
 

--- a/tests/test_ingress_github_context.py
+++ b/tests/test_ingress_github_context.py
@@ -50,6 +50,24 @@ def test_extract_issue_context_from_pr_issue_object() -> None:
     assert ctx.issue_number == 99
 
 
+def test_apply_relayed_context_instructs_mcp_for_missing_webhook_fields() -> None:
+    payload = {
+        "pull_request": {
+            "number": 3,
+            "head": {"ref": "fix", "sha": "abc"},
+        },
+    }
+    additional, _setup = igc.apply_relayed_ingress_context(
+        json.dumps(payload),
+        "",
+        [],
+        ingress_event_name="pull_request",
+    )
+    assert "GitHub data not guaranteed in the relay payload" in additional
+    assert "pull_request_read" in additional
+    assert "issue_read" in additional
+
+
 def test_apply_relayed_context_prepends_instructions_and_checkout() -> None:
     payload = {
         "action": "opened",
@@ -101,3 +119,85 @@ def test_apply_relayed_context_noop_without_target() -> None:
     additional, setup = igc.apply_relayed_ingress_context("{}", "Platform rules", [])
     assert additional == "Platform rules"
     assert setup == []
+
+
+def test_prepare_relayed_event_passthrough_when_small() -> None:
+    event = {"action": "opened", "pull_request": {"number": 1, "extra": "kept"}}
+    payload, mode = igc.prepare_relayed_github_event(event, max_chars=10_000)
+    assert mode == igc.RELAY_PREPARE_MODE_PASSTHROUGH
+    assert payload["pull_request"]["extra"] == "kept"
+
+
+def test_prepare_relayed_event_slims_large_pull_request() -> None:
+    event = {
+        "action": "synchronize",
+        "pull_request": {
+            "number": 1234,
+            "title": "Large change",
+            "head": {"ref": "feature/x", "sha": "abc"},
+            "user": {"login": "dependabot[bot]", "id": 999},
+            "labels": [{"id": 1, "name": "oblt-aw/triage/foo"}],
+            "body": "x" * 50_000,
+            "commits": [{"sha": "a" * 40}] * 200,
+            "files": [{"filename": f"path/{i}.go"} for i in range(500)],
+        },
+    }
+    payload, mode = igc.prepare_relayed_github_event(event)
+    payload_json, json_mode = igc.prepare_relayed_github_event_json(event)
+
+    assert mode == igc.RELAY_PREPARE_MODE_SLIM
+    assert json_mode == igc.RELAY_PREPARE_MODE_SLIM
+    assert payload["pull_request"]["number"] == 1234
+    assert payload["pull_request"]["head"] == {"ref": "feature/x", "sha": "abc"}
+    assert payload["pull_request"]["labels"] == [{"name": "oblt-aw/triage/foo"}]
+    assert "body" not in payload["pull_request"]
+    assert "commits" not in payload["pull_request"]
+    assert len(payload_json) < igc.RELAY_EVENT_JSON_MAX_CHARS
+    assert len(json.dumps(event)) > igc.RELAY_EVENT_JSON_MAX_CHARS
+
+
+def test_prepare_relayed_event_truncates_huge_comment_body() -> None:
+    event = {
+        "action": "created",
+        "issue": {"number": 1, "labels": [{"name": "x"}]},
+        "comment": {
+            "id": 9,
+            "body": "/ai implement\n" + ("z" * 70_000),
+            "author_association": "MEMBER",
+            "user": {"login": "alice"},
+        },
+    }
+    slim = igc.slim_relayed_github_event(event)
+    assert igc._relay_json_size(slim) > igc.RELAY_EVENT_JSON_MAX_CHARS
+
+    payload, mode = igc.prepare_relayed_github_event(event)
+    assert mode == igc.RELAY_PREPARE_MODE_TRUNCATED
+    assert payload["comment"]["body"].startswith("/ai implement")
+    assert len(payload["comment"]["body"]) < len(event["comment"]["body"])
+    assert igc._relay_json_size(payload) <= igc.RELAY_EVENT_JSON_MAX_CHARS
+
+
+def test_slim_relayed_github_event_preserves_issue_comment_routing_fields() -> None:
+    event = {
+        "action": "created",
+        "issue": {
+            "number": 9,
+            "labels": [{"name": "oblt-aw/ai/fix-ready"}],
+        },
+        "comment": {
+            "id": 42,
+            "body": "/ai implement",
+            "author_association": "MEMBER",
+            "user": {"login": "octocat"},
+        },
+    }
+    slim = igc.slim_relayed_github_event(event)
+    assert slim["issue"]["number"] == 9
+    assert slim["comment"]["body"] == "/ai implement"
+    assert slim["comment"]["author_association"] == "MEMBER"
+
+
+def test_slim_relayed_github_event_marks_pr_issues() -> None:
+    event = {"issue": {"number": 5, "pull_request": {"url": "https://example/pr"}}}
+    slim = igc.slim_relayed_github_event(event)
+    assert slim["issue"]["pull_request"] == {}


### PR DESCRIPTION
## Summary

- Add `prepare-relayed-github-event` composite action and `prepare_relayed_github_event_json()` so trigger workflows passthrough small webhooks, slim large ones, or truncate long non-routing strings when needed—fixing `inputs are too large` on `workflow_dispatch`.
- Document the relay payload contract in `docs/workflows/relayed-event-payload.md` and extend relayed agent instructions to fetch omitted webhook data via GitHub MCP.
- Add Cursor/AGENTS rules: edit client triggers under `remote-workflow-template/` only; do not hand-edit distributed copies under `.github/workflows/` (sync via `distribute-client-workflow`).

## Test plan

- [x] `python3 -m pytest tests/test_ingress_github_context.py`
- [ ] Merge to `main` so `prepare-relayed-github-event` action is available at `@main`
- [ ] Run `distribute-client-workflow` (or consumer sync PR) to update installed `trigger-oblt-aw.yml` / `trigger-docs-aw.yml` in target repos
- [ ] Reproduce a large `pull_request` `synchronize` on a consumer repo and confirm dispatch succeeds

Fixes https://github.com/elastic/observability-robots/actions/runs/26937679514

Related issue: https://github.com/elastic/observability-robots/issues/4614