### PR TITLE
fix(workflows): extract full APM CLI bundle in resolve-apm-assets

### DIFF
--- a/.github/workflows/aw-resolve-apm-assets.yml
+++ b/.github/workflows/aw-resolve-apm-assets.yml
@@ -135,10 +135,10 @@ jobs:
           curl -fsSL "${BASE_URL}/${TARBALL}.sha256" -o "/tmp/${TARBALL}.sha256"
           EXPECTED="$(awk '{print $1}' "/tmp/${TARBALL}.sha256")"
           echo "${EXPECTED}  /tmp/${TARBALL}" | sha256sum -c
-          mkdir -p "${HOME}/.local/bin"
-          tar -xzf "/tmp/${TARBALL}" -C /tmp "apm-${OS}-${ARCH}/apm"
-          install -m 0755 "/tmp/apm-${OS}-${ARCH}/apm" "${HOME}/.local/bin/apm"
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          APM_DIR="${HOME}/.local/apm"
+          mkdir -p "${APM_DIR}"
+          tar -xzf "/tmp/${TARBALL}" -C "${APM_DIR}" --strip-components=1
+          echo "${APM_DIR}" >> "${GITHUB_PATH}"
 
       - name: Install agent packages from apm.yml
         if: >-


### PR DESCRIPTION
## Summary

- Fix `aw-resolve-apm-assets` APM CLI installation by extracting the full PyInstaller onedir bundle (`apm` + `_internal`) into `~/.local/apm` instead of copying only the binary.
- Restores `apm install` for consumer repositories with an `apm.yml` manifest.

## Problem

The failing job copied only the `apm` executable to `~/.local/bin/apm`. The Microsoft APM v0.16.0 Linux release expects a sibling `_internal/` directory (including `libpython3.12.so.1.0`). Without it, `apm install` fails with PyInstaller error `PYI-2273`.

Failed CI job: https://github.com/elastic/observability-robots/actions/runs/27001746308/job/79683645891

## Test plan

- [ ] Merge and re-run the `oblt-aw-agent-suggestions` workflow in `elastic/observability-robots`
- [ ] Confirm `resolve-apm-assets / resolve` passes **Install agent packages from apm.yml**
- [ ] Confirm repos without `apm.yml` are unaffected (install steps remain gated)

Related issue: https://github.com/elastic/observability-robots/issues/4626
