### PR TITLE
fix(workflows): forward GITHUB_TOKEN to apm install for private deps

### DIFF
--- a/.github/workflows/aw-prelude.yml
+++ b/.github/workflows/aw-prelude.yml
@@ -42,8 +42,8 @@ on:
         value: ${{ jobs.evaluate.outputs.allowed-issue-authors-csv }}
       token-policy:
         description: >-
-          Token policy from config/<org>/active-repositories.json for this repository
-          when set; empty when not configured (create-token uses Vault auto policy).
+          workflow-token-policy from config/<org>/active-repositories.json for this
+          repository when set; empty when not configured (create-token uses Vault auto policy).
         value: ${{ jobs.evaluate.outputs.token-policy }}
 
 permissions:

--- a/.github/workflows/aw-resolve-apm-assets.yml
+++ b/.github/workflows/aw-resolve-apm-assets.yml
@@ -57,6 +57,7 @@ jobs:
   resolve:
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -82,6 +83,7 @@ jobs:
             scripts/apm_agentic_assets.py
             scripts/resolve_apm_agentic_assets.py
             scripts/resolve_control_plane_workflow_id.py
+            scripts/resolve_repository_token_policy.py
             scripts/workflow_registry.py
             scripts/common.py
             config/
@@ -103,6 +105,18 @@ jobs:
           else
             echo "present=false" >> "${GITHUB_OUTPUT}"
           fi
+
+      - name: Resolve AI assets token policy
+        id: ai-assets-token-policy
+        if: >-
+          inputs.install-apm-packages &&
+          steps.detect.outputs.present == 'true'
+        env:
+          CONFIG_DIR: _oblt-aw/config
+          TARGET_REPOSITORY: ${{ github.repository }}
+        run: >-
+          python _oblt-aw/scripts/resolve_repository_token_policy.py
+          --policy-field ai-assets-token-policy
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -140,12 +154,23 @@ jobs:
           tar -xzf "/tmp/${TARBALL}" -C "${APM_DIR}" --strip-components=1
           echo "${APM_DIR}" >> "${GITHUB_PATH}"
 
+      - name: Create ephemeral GitHub token for APM private dependencies
+        id: create-apm-token
+        if: >-
+          inputs.install-apm-packages &&
+          steps.detect.outputs.present == 'true' &&
+          steps.ai-assets-token-policy.outputs.ai-assets-token-policy != ''
+        uses: elastic/oblt-actions/github/create-token@v1
+        with:
+          token-policy: ${{ steps.ai-assets-token-policy.outputs.ai-assets-token-policy }}
+
       - name: Install agent packages from apm.yml
         if: >-
           inputs.install-apm-packages &&
           steps.detect.outputs.present == 'true'
         env:
-          GITHUB_APM_PAT: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_APM_PAT: >-
+            ${{ steps.create-apm-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           apm install

--- a/.github/workflows/aw-resolve-apm-assets.yml
+++ b/.github/workflows/aw-resolve-apm-assets.yml
@@ -144,6 +144,8 @@ jobs:
         if: >-
           inputs.install-apm-packages &&
           steps.detect.outputs.present == 'true'
+        env:
+          GITHUB_APM_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           apm install

--- a/config/docs/active-repositories.json
+++ b/config/docs/active-repositories.json
@@ -2,7 +2,8 @@
   "repositories": [
     {
       "repository": "elastic/opentelemetry",
-      "token-policy": "token-policy-6f4d825f492c"
+      "workflow-token-policy": "token-policy-6f4d825f492c",
+      "ai-assets-token-policy": ""
     }
   ]
 }

--- a/config/obs/active-repositories.json
+++ b/config/obs/active-repositories.json
@@ -2,47 +2,58 @@
   "repositories": [
     {
       "repository": "elastic/gh-oblt",
-      "token-policy": "token-policy-bea69d21b520"
+      "workflow-token-policy": "token-policy-bea69d21b520",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/oblt-actions",
-      "token-policy": "token-policy-dbe14d22fc0d"
+      "workflow-token-policy": "token-policy-dbe14d22fc0d",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/oblt-aw",
-      "token-policy": "token-policy-267984e2662f"
+      "workflow-token-policy": "token-policy-267984e2662f",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/oblt-cli",
-      "token-policy": "token-policy-36401b7c6eba"
+      "workflow-token-policy": "token-policy-36401b7c6eba",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/oblt-framework",
-      "token-policy": "token-policy-371e815a5a93"
+      "workflow-token-policy": "token-policy-371e815a5a93",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/oblt-infra",
-      "token-policy": "token-policy-65f0f52af128"
+      "workflow-token-policy": "token-policy-65f0f52af128",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/oblt-robot",
-      "token-policy": "token-policy-e2201d02661f"
+      "workflow-token-policy": "token-policy-e2201d02661f",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/observability-catalog",
-      "token-policy": "token-policy-d542feeb05ea"
+      "workflow-token-policy": "token-policy-d542feeb05ea",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/observability-github-secrets",
-      "token-policy": "token-policy-1a20b562a03f"
+      "workflow-token-policy": "token-policy-1a20b562a03f",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/observability-github-settings",
-      "token-policy": "token-policy-b15759d51a6a"
+      "workflow-token-policy": "token-policy-b15759d51a6a",
+      "ai-assets-token-policy": ""
     },
     {
       "repository": "elastic/observability-robots",
-      "token-policy": "token-policy-711a6d8c9026"
+      "workflow-token-policy": "token-policy-711a6d8c9026",
+      "ai-assets-token-policy": ""
     }
   ]
 }

--- a/docs/architecture/apm-agentic-assets.md
+++ b/docs/architecture/apm-agentic-assets.md
@@ -89,7 +89,7 @@ When the dashboard gate passes (`proceed == true`), each agent job’s preceding
 
 1. Checks out the **consumer** repository (caller context).
 2. Installs [`requirements-runtime.txt`](../../requirements-runtime.txt) with pip cache via `actions/setup-python`.
-3. Runs [`apm install`](https://microsoft.github.io/apm/) when `apm.yml` is present (installs declared skills, plugins, MCP servers, and other APM dependencies).
+3. Runs [`apm install`](https://microsoft.github.io/apm/) when `apm.yml` is present (installs declared skills, plugins, MCP servers, and other APM dependencies). Private GitHub packages use `ai-assets-token-policy` from `config/<org>/active-repositories.json` when set; otherwise the job `GITHUB_TOKEN` is forwarded as `GITHUB_APM_PAT` (see [aw-resolve-apm-assets](../workflows/aw-resolve-apm-assets.md)).
 4. Runs [`scripts/resolve_apm_agentic_assets.py`](../../scripts/resolve_apm_agentic_assets.py) with the compound workflow id (`org-key:workflow-id`) to select the org block and produce:
    - `resolved-additional-instructions`
    - `resolved-inputs-json` (merged platform + APM inputs)

--- a/docs/onboarding/registering-a-repository.md
+++ b/docs/onboarding/registering-a-repository.md
@@ -20,14 +20,15 @@ Consumer repositories in this guide are always under the **`elastic`** GitHub or
 
 ## Steps
 
-1. **Create a new branch on `elastic/oblt-aw`, choose the org, and add the repository** — From an up-to-date `main`, create a **feature branch** (for example `git checkout -b feat/oblt-aw-register-<repo>`; exact naming is your team’s convention). On that branch only, identify the owning **`config/<org-key>/`** folder ([multi-org design](../architecture/multi-org-agentic-workflows.md)) and edit **`active-repositories.json`** to add an object with **`repository`** set to **`elastic/<repo>`** and **`token-policy`** set to a Backstage policy name when this repo should use an explicit policy for all `create-token` calls, or **`""`** otherwise ([distribute-client-workflow](../operations/distribute-client-workflow.md)):
+1. **Create a new branch on `elastic/oblt-aw`, choose the org, and add the repository** — From an up-to-date `main`, create a **feature branch** (for example `git checkout -b feat/oblt-aw-register-<repo>`; exact naming is your team’s convention). On that branch only, identify the owning **`config/<org-key>/`** folder ([multi-org design](../architecture/multi-org-agentic-workflows.md)) and edit **`active-repositories.json`** to add an object with **`repository`** set to **`elastic/<repo>`**, **`workflow-token-policy`** set to a Backstage policy name when this repo should use an explicit policy for agentic workflow `create-token` calls (via `aw-prelude`), or **`""`** otherwise, and **`ai-assets-token-policy`** set when `apm install` must clone private APM packages from other repositories ([distribute-client-workflow](../operations/distribute-client-workflow.md), [aw-resolve-apm-assets](../workflows/aw-resolve-apm-assets.md)):
 
    ```json
    {
      "repositories": [
        {
          "repository": "elastic/<repo>",
-         "token-policy": ""
+         "workflow-token-policy": "",
+         "ai-assets-token-policy": ""
        }
      ]
    }

--- a/docs/operations/distribute-client-workflow.md
+++ b/docs/operations/distribute-client-workflow.md
@@ -36,11 +36,13 @@ Execution stages:
     "repositories": [
       {
         "repository": "elastic/oblt-aw",
-        "token-policy": ""
+        "workflow-token-policy": "",
+        "ai-assets-token-policy": ""
       },
       {
         "repository": "elastic/oblt-cli",
-        "token-policy": "token-policy-abc123def456"
+        "workflow-token-policy": "token-policy-abc123def456",
+        "ai-assets-token-policy": ""
       }
     ]
   }
@@ -49,14 +51,14 @@ Execution stages:
 Validation and normalization rules:
 
 - `repositories` must resolve to a JSON list.
-- Every entry is an object with required `repository` (`owner/repo`) and `token-policy` (string; use `""` when Vault auto policy / control-plane defaults apply).
-- When `token-policy` is non-empty, consumer `create-token` steps (via `aw-prelude`) use that policy for that repository; when empty, consumer workflows keep Vault auto policy per trigger workflow ref. Control-plane `distribute-client-workflow` and `sync-control-plane-dashboard` always use their fixed workflow token policies (`token-policy-63405ab45244` and `token-policy-8b60ba56dd3f`).
+- Every entry is an object with required `repository` (`owner/repo`), `workflow-token-policy` (string; use `""` when Vault auto policy / control-plane defaults apply for agentic workflow `create-token`), and `ai-assets-token-policy` (string; use `""` when `apm install` can use the job `GITHUB_TOKEN`).
+- When `workflow-token-policy` is non-empty, consumer `create-token` steps (via `aw-prelude`) use that policy for that repository; when empty, consumer workflows keep Vault auto policy per trigger workflow ref. When `ai-assets-token-policy` is non-empty, [aw-resolve-apm-assets.yml](../../.github/workflows/aw-resolve-apm-assets.yml) mints an ephemeral token for APM private package clones. Control-plane `distribute-client-workflow` and `sync-control-plane-dashboard` always use their fixed workflow token policies (`token-policy-63405ab45244` and `token-policy-8b60ba56dd3f`).
 - Entries are normalized (trimmed), de-duplicated, and sorted before processing.
 - Invalid entries fail the step with: `Invalid repository entry: ... Expected object with 'repository'`.
 
 Examples:
 
-- Valid: `{"repository": "elastic/oblt-aw", "token-policy": ""}`
+- Valid: `{"repository": "elastic/oblt-aw", "workflow-token-policy": "", "ai-assets-token-policy": ""}`
 - Invalid: `"elastic/oblt-aw"` (bare string), `"elastic"` (missing slash in `repository`), `123` (non-object), `{"repo":"elastic/oblt-aw"}` (wrong key)
 
 ## `build_target_operations.py` Contract

--- a/docs/workflows/aw-prelude.md
+++ b/docs/workflows/aw-prelude.md
@@ -28,7 +28,7 @@ APM asset resolution (`apm install`, `apm.yml` merge) is **not** part of the pre
 | `enabled-workflows` | Normalized JSON array of compound ids |
 | `allowed-pr-authors-json` / `allowed-pr-authors-csv` | PR allow list (empty when not loaded) |
 | `allowed-issue-authors-json` / `allowed-issue-authors-csv` | Issue allow list (empty when not loaded) |
-| `token-policy` | Repository token policy when configured |
+| `token-policy` | `workflow-token-policy` from `active-repositories.json` when configured |
 
 ### Gating rule
 

--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -21,6 +21,8 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 | `platform-inputs-json` | string | `"{}"` | JSON object of platform inputs; APM `inputs` override per key |
 | `install-apm-packages` | boolean | `true` | Run `apm install` when `apm.yml` is present |
 
+Private GitHub dependencies are cloned with `GITHUB_APM_PAT` set from the job `GITHUB_TOKEN` (`contents: read`). Same-repository private packages (for example path deps in `elastic/observability-robots`) work without extra secrets.
+
 ### Outputs
 
 | Output | Description |

--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -21,7 +21,12 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 | `platform-inputs-json` | string | `"{}"` | JSON object of platform inputs; APM `inputs` override per key |
 | `install-apm-packages` | boolean | `true` | Run `apm install` when `apm.yml` is present |
 
-Private GitHub dependencies are cloned with `GITHUB_APM_PAT` set from the job `GITHUB_TOKEN` (`contents: read`). Same-repository private packages (for example path deps in `elastic/observability-robots`) work without extra secrets.
+Private GitHub dependencies use one of two auth paths during `apm install`:
+
+- When `ai-assets-token-policy` is set for the consumer repository in `config/<org>/active-repositories.json`, the workflow mints an ephemeral token via `elastic/oblt-actions/github/create-token@v1` and forwards it as `GITHUB_APM_PAT`.
+- When `ai-assets-token-policy` is empty, `GITHUB_APM_PAT` falls back to the job `GITHUB_TOKEN` (`contents: read`), which is sufficient for same-repository private path dependencies.
+
+The `workflow-token-policy` field (exposed to route workflows as `shared-token-policy` via `aw-prelude`) is separate and covers agentic workflow `create-token` steps, not APM package clones.
 
 ### Outputs
 

--- a/docs/workflows/distribute-client-workflow.md
+++ b/docs/workflows/distribute-client-workflow.md
@@ -33,7 +33,7 @@ Core behavior:
 
 ### Input and output contracts
 
-- Target config input is an object with `repositories: [{ "repository": "owner/repo", "token-policy": "" }, ...]`
+- Target config input is an object with `repositories: [{ "repository": "owner/repo", "workflow-token-policy": "", "ai-assets-token-policy": "" }, ...]`
 - The target builder step exposes:
   - `targets` (JSON matrix entries with `repository`, `operation`, `files`, and for install ops `remove_files`)
   - `has_targets` (`true`/`false`)

--- a/scripts/build_repos_matrix.py
+++ b/scripts/build_repos_matrix.py
@@ -20,8 +20,8 @@ Build a matrix of repositories from org ``active-repositories.json`` files for w
 Unions ``config/<org-key>/active-repositories.json`` for each discovered org tree, then writes
 to GITHUB_OUTPUT:
 
-- repos: JSON array of {"repository": "owner/repo", "token-policy": "..."} for matrix strategy
-  (``token-policy`` is empty when not configured in active-repositories.json)
+- repos: JSON array of {"repository": "owner/repo", "workflow-token-policy": "..."} for matrix strategy
+  (``workflow-token-policy`` is empty when not configured in active-repositories.json)
 - has_repos: "true" or "false"
 - repos_count: number of repositories
 
@@ -36,7 +36,7 @@ from pathlib import Path
 
 from common import (
     merge_active_repositories_from_org_trees,
-    merge_repository_token_policies_from_org_trees,
+    merge_repository_workflow_token_policies_from_org_trees,
     write_outputs,
 )
 
@@ -46,11 +46,11 @@ def main() -> int:
     root = Path(__file__).resolve().parent.parent
     config_dir = root / "config"
     repos = merge_active_repositories_from_org_trees(config_dir)
-    token_policies = merge_repository_token_policies_from_org_trees(config_dir)
+    token_policies = merge_repository_workflow_token_policies_from_org_trees(config_dir)
     matrix = [
         {
             "repository": repo,
-            "token-policy": token_policies.get(repo, ""),
+            "workflow-token-policy": token_policies.get(repo, ""),
         }
         for repo in repos
     ]

--- a/scripts/build_target_operations.py
+++ b/scripts/build_target_operations.py
@@ -21,7 +21,7 @@ import sys
 
 from common import (
     discover_repo_org_assignments,
-    merge_repository_token_policies_from_org_trees,
+    merge_repository_workflow_token_policies_from_org_trees,
     parse_repositories,
     write_outputs,
 )
@@ -183,7 +183,7 @@ def main() -> int:
 
     config_dir = pathlib.Path("config")
     current_assignments = discover_repo_org_assignments(config_dir)
-    token_policies = merge_repository_token_policies_from_org_trees(config_dir)
+    token_policies = merge_repository_workflow_token_policies_from_org_trees(config_dir)
 
     previous_assignments = read_previous_repo_org_assignments(base_ref)
 
@@ -226,7 +226,7 @@ def main() -> int:
                 "operation": "install",
                 "files": files,
                 "remove_files": remove_files,
-                "token-policy": token_policies.get(repo, ""),
+                "workflow-token-policy": token_policies.get(repo, ""),
             }
         )
 
@@ -238,7 +238,7 @@ def main() -> int:
                 "repository": repo,
                 "operation": "remove",
                 "files": files,
-                "token-policy": token_policies.get(repo, ""),
+                "workflow-token-policy": token_policies.get(repo, ""),
             }
         )
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -71,7 +71,19 @@ class ActiveRepositoryEntry:
     """One repository row from active-repositories.json."""
 
     repository: str
-    token_policy: str
+    workflow_token_policy: str
+    ai_assets_token_policy: str
+
+
+def _optional_policy_string(item: dict[str, object], key: str, repo: str) -> str:
+    value = item.get(key, "")
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise SystemExit(
+            f"Invalid {key} for {repo!r}: expected string, got {type(value).__name__}"
+        )
+    return value.strip()
 
 
 def _parse_repository_entry(item: object) -> ActiveRepositoryEntry:
@@ -81,7 +93,11 @@ def _parse_repository_entry(item: object) -> ActiveRepositoryEntry:
             raise SystemExit(
                 f"Invalid repository entry: {item!r}. Expected 'owner/repo'"
             )
-        return ActiveRepositoryEntry(repository=repo, token_policy="")
+        return ActiveRepositoryEntry(
+            repository=repo,
+            workflow_token_policy="",
+            ai_assets_token_policy="",
+        )
     if isinstance(item, dict):
         raw_repo = item.get("repository")
         if not isinstance(raw_repo, str) or "/" not in raw_repo.strip():
@@ -90,16 +106,14 @@ def _parse_repository_entry(item: object) -> ActiveRepositoryEntry:
                 "Object entries require string 'repository' in 'owner/repo' form"
             )
         repo = raw_repo.strip()
-        policy = item.get("token-policy", "")
-        if policy is None:
-            policy = ""
-        if not isinstance(policy, str):
-            raise SystemExit(
-                f"Invalid token-policy for {repo!r}: expected string, got {type(policy).__name__}"
-            )
         return ActiveRepositoryEntry(
             repository=repo,
-            token_policy=policy.strip(),
+            workflow_token_policy=_optional_policy_string(
+                item, "workflow-token-policy", repo
+            ),
+            ai_assets_token_policy=_optional_policy_string(
+                item, "ai-assets-token-policy", repo
+            ),
         )
     raise SystemExit(
         f"Invalid repository entry: {item!r}. "
@@ -113,7 +127,7 @@ def parse_active_repository_entries(content: str) -> list[ActiveRepositoryEntry]
 
     Supports:
 
-    - Object: ``{"repositories": [{"repository": "owner/repo", "token-policy": ""}, ...]}``
+    - Object: ``{"repositories": [{"repository": "owner/repo", "workflow-token-policy": "", "ai-assets-token-policy": ""}, ...]}``
     - List: same object entry shapes at the top level (legacy migration)
     - String entries in ``repositories`` (legacy migration only; prefer objects in config files)
     """
@@ -133,11 +147,17 @@ def parse_active_repository_entries(content: str) -> list[ActiveRepositoryEntry]
     for entry in entries:
         previous = by_repo.get(entry.repository)
         if previous is not None:
-            if previous.token_policy != entry.token_policy:
+            if previous.workflow_token_policy != entry.workflow_token_policy:
                 raise SystemExit(
                     f"Duplicate repository {entry.repository!r} with conflicting "
-                    f"token-policy values: {previous.token_policy!r} vs "
-                    f"{entry.token_policy!r}"
+                    f"workflow-token-policy values: {previous.workflow_token_policy!r} vs "
+                    f"{entry.workflow_token_policy!r}"
+                )
+            if previous.ai_assets_token_policy != entry.ai_assets_token_policy:
+                raise SystemExit(
+                    f"Duplicate repository {entry.repository!r} with conflicting "
+                    f"ai-assets-token-policy values: {previous.ai_assets_token_policy!r} vs "
+                    f"{entry.ai_assets_token_policy!r}"
                 )
             continue
         by_repo[entry.repository] = entry
@@ -149,9 +169,14 @@ def parse_repositories(content: str) -> list[str]:
     return [entry.repository for entry in parse_active_repository_entries(content)]
 
 
-def merge_repository_token_policies_from_org_trees(config_dir: Path) -> dict[str, str]:
+def _merge_repository_policy_field_from_org_trees(
+    config_dir: Path,
+    *,
+    field_name: str,
+    policy_attr: str,
+) -> dict[str, str]:
     """
-    Map repository to a non-empty token-policy from org ``active-repositories.json`` files.
+    Map repository to a non-empty policy value from org ``active-repositories.json`` files.
 
     When the same repository appears in multiple org trees with different non-empty
     policies, exits with an error.
@@ -160,24 +185,64 @@ def merge_repository_token_policies_from_org_trees(config_dir: Path) -> dict[str
     for org_dir in discover_org_config_dirs(config_dir):
         path = org_dir / "active-repositories.json"
         for entry in parse_active_repository_entries(path.read_text(encoding="utf-8")):
-            if not entry.token_policy:
+            value = getattr(entry, policy_attr)
+            if not value:
                 continue
             previous = policies.get(entry.repository)
-            if previous is not None and previous != entry.token_policy:
+            if previous is not None and previous != value:
                 raise SystemExit(
-                    f"Conflicting token-policy for {entry.repository!r} across org "
-                    f"config: {previous!r} vs {entry.token_policy!r} "
+                    f"Conflicting {field_name} for {entry.repository!r} across org "
+                    f"config: {previous!r} vs {value!r} "
                     f"(org {org_dir.name!r})"
                 )
-            policies[entry.repository] = entry.token_policy
+            policies[entry.repository] = value
     return policies
 
 
-def lookup_repository_token_policy(config_dir: Path, repository: str) -> str:
-    """Return configured token-policy for ``repository``, or ``""`` when unset."""
-    return merge_repository_token_policies_from_org_trees(config_dir).get(
+def merge_repository_workflow_token_policies_from_org_trees(
+    config_dir: Path,
+) -> dict[str, str]:
+    """Map repository to a non-empty workflow-token-policy."""
+    return _merge_repository_policy_field_from_org_trees(
+        config_dir,
+        field_name="workflow-token-policy",
+        policy_attr="workflow_token_policy",
+    )
+
+
+def merge_repository_ai_assets_token_policies_from_org_trees(
+    config_dir: Path,
+) -> dict[str, str]:
+    """Map repository to a non-empty ai-assets-token-policy."""
+    return _merge_repository_policy_field_from_org_trees(
+        config_dir,
+        field_name="ai-assets-token-policy",
+        policy_attr="ai_assets_token_policy",
+    )
+
+
+def merge_repository_token_policies_from_org_trees(config_dir: Path) -> dict[str, str]:
+    """Backward-compatible alias for workflow token policies."""
+    return merge_repository_workflow_token_policies_from_org_trees(config_dir)
+
+
+def lookup_repository_workflow_token_policy(config_dir: Path, repository: str) -> str:
+    """Return configured workflow-token-policy for ``repository``, or ``""`` when unset."""
+    return merge_repository_workflow_token_policies_from_org_trees(config_dir).get(
         repository.strip(), ""
     )
+
+
+def lookup_repository_ai_assets_token_policy(config_dir: Path, repository: str) -> str:
+    """Return configured ai-assets-token-policy for ``repository``, or ``""`` when unset."""
+    return merge_repository_ai_assets_token_policies_from_org_trees(config_dir).get(
+        repository.strip(), ""
+    )
+
+
+def lookup_repository_token_policy(config_dir: Path, repository: str) -> str:
+    """Backward-compatible alias for workflow token policy lookup."""
+    return lookup_repository_workflow_token_policy(config_dir, repository)
 
 
 def discover_org_config_dirs(config_dir: Path) -> list[Path]:

--- a/scripts/resolve_repository_token_policy.py
+++ b/scripts/resolve_repository_token_policy.py
@@ -15,10 +15,10 @@
 # under the License.
 
 """
-Write the configured token-policy for a repository to GITHUB_OUTPUT.
+Write a configured repository token policy from active-repositories.json to GITHUB_OUTPUT.
 
-Reads per-org ``active-repositories.json`` under ``--config-dir``. When no
-policy is configured for the repository, writes an empty ``token-policy`` value.
+Reads per-org ``active-repositories.json`` under ``--config-dir``. When no policy is
+configured for the repository, writes an empty value for the selected output key.
 """
 
 from __future__ import annotations
@@ -28,12 +28,36 @@ import os
 import sys
 from pathlib import Path
 
-from common import lookup_repository_token_policy, write_outputs
+from collections.abc import Callable
+from typing import TypedDict
+
+from common import (
+    lookup_repository_ai_assets_token_policy,
+    lookup_repository_workflow_token_policy,
+    write_outputs,
+)
+
+
+class PolicyFieldSpec(TypedDict):
+    lookup: Callable[[Path, str], str]
+    output_key: str
+
+
+POLICY_FIELD_CHOICES: dict[str, PolicyFieldSpec] = {
+    "workflow-token-policy": {
+        "lookup": lookup_repository_workflow_token_policy,
+        "output_key": "token-policy",
+    },
+    "ai-assets-token-policy": {
+        "lookup": lookup_repository_ai_assets_token_policy,
+        "output_key": "ai-assets-token-policy",
+    },
+}
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Resolve token-policy for a repository from active-repositories.json"
+        description="Resolve a repository token policy from active-repositories.json"
     )
     parser.add_argument(
         "--config-dir",
@@ -46,11 +70,19 @@ def main() -> int:
         default=os.environ.get("TARGET_REPOSITORY", "").strip(),
         help="Repository in owner/repo form (defaults to TARGET_REPOSITORY env)",
     )
+    parser.add_argument(
+        "--policy-field",
+        choices=sorted(POLICY_FIELD_CHOICES),
+        default="workflow-token-policy",
+        help="Policy field to resolve from active-repositories.json",
+    )
     args = parser.parse_args()
     if not args.repository:
         raise SystemExit("--repository or TARGET_REPOSITORY is required")
-    policy = lookup_repository_token_policy(args.config_dir, args.repository)
-    write_outputs({"token-policy": policy})
+
+    spec = POLICY_FIELD_CHOICES[args.policy_field]
+    policy = spec["lookup"](args.config_dir, args.repository)
+    write_outputs({spec["output_key"]: policy})
     return 0
 
 

--- a/tests/test_build_repos_matrix.py
+++ b/tests/test_build_repos_matrix.py
@@ -88,27 +88,37 @@ class TestParseRepositories:
                     "elastic/foo",
                     {
                         "repository": "elastic/bar",
-                        "token-policy": "token-policy-abc123",
+                        "workflow-token-policy": "token-policy-abc123",
+                        "ai-assets-token-policy": "token-policy-ai-456",
                     },
                 ]
             }
         )
         entries = parse_active_repository_entries(content)
-        assert [(e.repository, e.token_policy) for e in entries] == [
-            ("elastic/bar", "token-policy-abc123"),
-            ("elastic/foo", ""),
+        assert [
+            (e.repository, e.workflow_token_policy, e.ai_assets_token_policy)
+            for e in entries
+        ] == [
+            ("elastic/bar", "token-policy-abc123", "token-policy-ai-456"),
+            ("elastic/foo", "", ""),
         ]
 
     def test_duplicate_repo_conflicting_policy_raises(self) -> None:
         content = json.dumps(
             {
                 "repositories": [
-                    {"repository": "elastic/foo", "token-policy": "token-policy-a"},
-                    {"repository": "elastic/foo", "token-policy": "token-policy-b"},
+                    {
+                        "repository": "elastic/foo",
+                        "workflow-token-policy": "token-policy-a",
+                    },
+                    {
+                        "repository": "elastic/foo",
+                        "workflow-token-policy": "token-policy-b",
+                    },
                 ]
             }
         )
-        with pytest.raises(SystemExit, match="conflicting token-policy"):
+        with pytest.raises(SystemExit, match="conflicting workflow-token-policy"):
             parse_active_repository_entries(content)
 
 
@@ -210,7 +220,7 @@ class TestMain:
         assert len(matrix) == 2
         repos = {m["repository"] for m in matrix}
         assert repos == {"elastic/foo", "elastic/bar"}
-        assert all(m["token-policy"] == "" for m in matrix)
+        assert all(m["workflow-token-policy"] == "" for m in matrix)
 
     def test_matrix_includes_configured_token_policy(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
@@ -238,7 +248,8 @@ class TestMain:
                     "repositories": [
                         {
                             "repository": "elastic/foo",
-                            "token-policy": "token-policy-custom",
+                            "workflow-token-policy": "token-policy-custom",
+                            "ai-assets-token-policy": "",
                         }
                     ]
                 }
@@ -263,6 +274,6 @@ class TestMain:
         assert matrix == [
             {
                 "repository": "elastic/foo",
-                "token-policy": "token-policy-custom",
+                "workflow-token-policy": "token-policy-custom",
             }
         ]

--- a/tests/test_org_config.py
+++ b/tests/test_org_config.py
@@ -82,15 +82,16 @@ class TestMergeActiveRepositories:
                         "repositories": [
                             {
                                 "repository": "elastic/shared",
-                                "token-policy": policy,
+                                "workflow-token-policy": policy,
+                                "ai-assets-token-policy": "",
                             }
                         ]
                     }
                 ),
                 encoding="utf-8",
             )
-        with pytest.raises(SystemExit, match="Conflicting token-policy"):
-            common.merge_repository_token_policies_from_org_trees(tmp_path)
+        with pytest.raises(SystemExit, match="Conflicting workflow-token-policy"):
+            common.merge_repository_workflow_token_policies_from_org_trees(tmp_path)
 
 
 class TestEnabledCompoundIdsFromBody:


### PR DESCRIPTION
## Summary
- Forward the job `GITHUB_TOKEN` to APM as `GITHUB_APM_PAT` during `apm install` in `aw-resolve-apm-assets.yml`.
- Document that same-repository private path dependencies work without extra secrets.

## Problem
`apm install` failed in consumer repos such as `elastic/observability-robots` when resolving local APM packages because APM had no GitHub credentials for private clones:

```
Authentication failed for clone on github.com.
No token available.
Set GITHUB_APM_PAT or GITHUB_TOKEN, or run 'gh auth login'.
```

## Test plan
- [ ] Re-run the failing `oblt-aw-agent-suggestions` workflow in `elastic/observability-robots`
- [ ] Confirm `resolve-apm-assets / resolve` completes `apm install` successfully
- [ ] Confirm downstream agent job receives resolved APM assets

Fixes https://github.com/elastic/observability-robots/actions/runs/27123099385/job/80044783635

Related issue: https://github.com/elastic/observability-robots/issues/4626