### PR TITLE
fix(workflows): grant id-token write for aw-resolve-apm-assets callers

### DIFF
--- a/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-issue-comment.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-issue-comment.yml
@@ -17,6 +17,7 @@ jobs:
       checks: read
       contents: read
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/docs-aw-event-issue-comment.yml@main # ratchet:exclude

--- a/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-issues.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-issues.yml
@@ -22,6 +22,7 @@ jobs:
       actions: read
       contents: read
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/docs-aw-event-issues.yml@main # ratchet:exclude

--- a/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-workflow-run.yml
+++ b/.github/remote-workflow-template/docs/.github/workflows/trigger-docs-aw-workflow-run.yml
@@ -23,6 +23,7 @@ jobs:
       actions: read
       checks: read
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/docs-aw-event-workflow-run.yml@main # ratchet:exclude

--- a/.github/remote-workflow-template/obs/.github/workflows/trigger-oblt-aw-issue-comment.yml
+++ b/.github/remote-workflow-template/obs/.github/workflows/trigger-oblt-aw-issue-comment.yml
@@ -13,6 +13,7 @@ jobs:
       actions: read
       contents: write
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/oblt-aw-event-issue-comment.yml@main # ratchet:exclude

--- a/.github/remote-workflow-template/obs/.github/workflows/trigger-oblt-aw-status.yml
+++ b/.github/remote-workflow-template/obs/.github/workflows/trigger-oblt-aw-status.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       issues: read
       pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/oblt-aw-event-status.yml@main # ratchet:exclude

--- a/.github/workflows/docs-aw-ai-menu.yml
+++ b/.github/workflows/docs-aw-ai-menu.yml
@@ -147,6 +147,9 @@ jobs:
     if: >-
       inputs.shared-proceed == 'true' &&
       needs.evaluate-trigger.outputs.triage_triggered == 'true'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: docs-aw-ai-menu.yml
@@ -173,6 +176,9 @@ jobs:
     if: >-
       inputs.shared-proceed == 'true' &&
       needs.evaluate-trigger.outputs.issue_scope_triggered == 'true'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: docs-aw-ai-menu.yml

--- a/.github/workflows/docs-aw-event-issue-comment.yml
+++ b/.github/workflows/docs-aw-event-issue-comment.yml
@@ -32,6 +32,7 @@ jobs:
       actions: read
       contents: read
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/docs-aw-ai-menu.yml
@@ -56,6 +57,7 @@ jobs:
       actions: read
       checks: read
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/docs-aw-pr-ai-menu.yml

--- a/.github/workflows/docs-aw-event-issues.yml
+++ b/.github/workflows/docs-aw-event-issues.yml
@@ -32,6 +32,7 @@ jobs:
       actions: read
       contents: read
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/docs-aw-ai-menu.yml

--- a/.github/workflows/docs-aw-event-workflow-run.yml
+++ b/.github/workflows/docs-aw-event-workflow-run.yml
@@ -32,6 +32,7 @@ jobs:
       actions: read
       checks: read
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/docs-aw-pr-ai-menu.yml

--- a/.github/workflows/docs-aw-pr-ai-menu.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu.yml
@@ -171,6 +171,9 @@ jobs:
     if: >-
       inputs.shared-proceed == 'true' &&
       needs.evaluate-trigger.outputs.docs_review_triggered == 'true'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: docs-aw-pr-ai-menu.yml

--- a/.github/workflows/oblt-aw-agent-suggestions.yml
+++ b/.github/workflows/oblt-aw-agent-suggestions.yml
@@ -31,6 +31,9 @@ permissions:
 jobs:
 
   resolve-apm-assets:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-agent-suggestions.yml

--- a/.github/workflows/oblt-aw-autodoc.yml
+++ b/.github/workflows/oblt-aw-autodoc.yml
@@ -32,6 +32,9 @@ jobs:
 
   # Step 1: Detect docs drift from recent code changes and create an issue with findings
   resolve-apm-assets-audit:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-autodoc.yml
@@ -79,6 +82,9 @@ jobs:
   resolve-apm-assets-fix:
     needs: audit
     if: needs.audit.outputs.created_issue_number != ''
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-autodoc.yml

--- a/.github/workflows/oblt-aw-automerge.yml
+++ b/.github/workflows/oblt-aw-automerge.yml
@@ -150,6 +150,9 @@ jobs:
     if: >-
       needs.verify.outputs.proceed == 'true' &&
       needs.check-dependency-collection.outputs.allowed == 'true'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-automerge.yml

--- a/.github/workflows/oblt-aw-dependency-review.yml
+++ b/.github/workflows/oblt-aw-dependency-review.yml
@@ -31,6 +31,9 @@ permissions:
 jobs:
 
   resolve-apm-assets:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-dependency-review.yml

--- a/.github/workflows/oblt-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/oblt-aw-duplicate-issue-detector.yml
@@ -37,6 +37,9 @@ jobs:
         (github.event_name == 'issues' && github.event.action == 'opened') ||
         github.event_name == 'workflow_dispatch'
       )
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-duplicate-issue-detector.yml

--- a/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
+++ b/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
@@ -38,6 +38,9 @@ jobs:
       github.event_name == 'status' &&
       github.event.state == 'failure' &&
       contains(github.event.context, 'buildkite')
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-estc-pr-buildkite-detective.yml

--- a/.github/workflows/oblt-aw-event-issue-comment.yml
+++ b/.github/workflows/oblt-aw-event-issue-comment.yml
@@ -36,6 +36,7 @@ jobs:
       actions: read
       contents: write
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/oblt-aw-issue-fixer.yml
@@ -62,6 +63,7 @@ jobs:
       actions: read
       contents: write
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/oblt-aw-mention-in-issue.yml

--- a/.github/workflows/oblt-aw-event-issues.yml
+++ b/.github/workflows/oblt-aw-event-issues.yml
@@ -31,6 +31,7 @@ jobs:
       actions: read
       contents: read
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/oblt-aw-issue-triage.yml
@@ -54,6 +55,7 @@ jobs:
       )
     permissions:
       contents: read
+      id-token: write
       issues: write
       pull-requests: read
     uses: ./.github/workflows/oblt-aw-duplicate-issue-detector.yml
@@ -108,6 +110,7 @@ jobs:
       actions: read
       contents: write
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/oblt-aw-security-fixer.yml
@@ -160,6 +163,7 @@ jobs:
       actions: read
       contents: write
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml

--- a/.github/workflows/oblt-aw-event-schedule.yml
+++ b/.github/workflows/oblt-aw-event-schedule.yml
@@ -27,6 +27,7 @@ jobs:
       fromJSON(needs.prelude.outputs.proceed-by-workflow)['oblt-aw-agent-suggestions.yml'] == 'true'
     permissions:
       contents: read
+      id-token: write
       issues: write
       pull-requests: read
     uses: ./.github/workflows/oblt-aw-agent-suggestions.yml
@@ -47,6 +48,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/oblt-aw-autodoc.yml
@@ -88,6 +90,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       issues: write
     uses: ./.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml
     with:

--- a/.github/workflows/oblt-aw-event-status.yml
+++ b/.github/workflows/oblt-aw-event-status.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       issues: read
       pull-requests: write
     uses: ./.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml

--- a/.github/workflows/oblt-aw-issue-fixer.yml
+++ b/.github/workflows/oblt-aw-issue-fixer.yml
@@ -34,6 +34,9 @@ jobs:
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
       !contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-') &&
       !contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-issue-fixer.yml

--- a/.github/workflows/oblt-aw-issue-triage.yml
+++ b/.github/workflows/oblt-aw-issue-triage.yml
@@ -35,6 +35,9 @@ jobs:
     if: >-
       github.event_name == 'issues' &&
       github.event.action == 'opened'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-issue-triage.yml

--- a/.github/workflows/oblt-aw-mention-in-issue.yml
+++ b/.github/workflows/oblt-aw-mention-in-issue.yml
@@ -39,6 +39,9 @@ jobs:
       startsWith(github.event.comment.body, '/ai') &&
       !startsWith(github.event.comment.body, '/ai implement') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-mention-in-issue.yml

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-detector.yml
@@ -51,6 +51,9 @@ jobs:
   resolve-apm-assets:
     needs: [discover]
     if: needs.discover.result == 'success' && needs.discover.outputs.workflows != '[]'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-resource-not-accessible-by-integration-detector.yml

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml
@@ -33,6 +33,9 @@ jobs:
       github.event.action == 'labeled' &&
       github.event.label.name == 'oblt-aw/ai/fix-ready' &&
       contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/res-not-accessible-by-integration')
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-resource-not-accessible-by-integration-fixer.yml

--- a/.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml
+++ b/.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml
@@ -39,6 +39,9 @@ jobs:
         (github.event.action == 'opened' && contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/detector/res-not-accessible-by-integration')) ||
         (github.event.action == 'labeled' && github.event.label.name == 'oblt-aw/detector/res-not-accessible-by-integration')
       )
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-resource-not-accessible-by-integration-triage.yml

--- a/.github/workflows/oblt-aw-security-fixer.yml
+++ b/.github/workflows/oblt-aw-security-fixer.yml
@@ -38,6 +38,9 @@ jobs:
         (github.event.label.name == 'oblt-aw/ai/fix-ready' && contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/triage/security-')) ||
         (startsWith(github.event.label.name, 'oblt-aw/triage/security-') && contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/ai/fix-ready'))
       )
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-security-fixer.yml

--- a/.github/workflows/oblt-aw-security-triage.yml
+++ b/.github/workflows/oblt-aw-security-triage.yml
@@ -38,6 +38,9 @@ jobs:
         (github.event.action == 'opened' && contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/detector/security')) ||
         (github.event.action == 'labeled' && github.event.label.name == 'oblt-aw/detector/security')
       )
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/aw-resolve-apm-assets.yml
     with:
       control-plane-workflow: oblt-aw-security-triage.yml

--- a/.github/workflows/trigger-oblt-aw-issue-comment.yml
+++ b/.github/workflows/trigger-oblt-aw-issue-comment.yml
@@ -13,6 +13,7 @@ jobs:
       actions: read
       contents: write
       discussions: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/oblt-aw-event-issue-comment.yml@main # ratchet:exclude

--- a/.github/workflows/trigger-oblt-aw-issue-comment.yml
+++ b/.github/workflows/trigger-oblt-aw-issue-comment.yml
@@ -13,7 +13,6 @@ jobs:
       actions: read
       contents: write
       discussions: write
-      id-token: write
       issues: write
       pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/oblt-aw-event-issue-comment.yml@main # ratchet:exclude

--- a/.github/workflows/trigger-oblt-aw-status.yml
+++ b/.github/workflows/trigger-oblt-aw-status.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       issues: read
       pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/oblt-aw-event-status.yml@main # ratchet:exclude

--- a/.github/workflows/trigger-oblt-aw-status.yml
+++ b/.github/workflows/trigger-oblt-aw-status.yml
@@ -14,7 +14,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      id-token: write
       issues: read
       pull-requests: write
     uses: elastic/oblt-aw/.github/workflows/oblt-aw-event-status.yml@main # ratchet:exclude


### PR DESCRIPTION
## Summary

- Add `id-token: write` to event orchestrator jobs that call route reusables invoking `aw-resolve-apm-assets.yml`, fixing nested workflow validation failures (for example issue triage on `issues.opened`).
- Align client trigger workflows and distributed templates that were missing `id-token: write` at the entry of the permission chain.

## Test plan

- [x] `python3 scripts/validate_aw_workflow_resolve_apm_assets.py`
- [x] `python3 scripts/validate_aw_workflow_prelude.py`
- [x] Pre-commit hooks (yamllint, actionlint)

Fixes https://github.com/elastic/observability-robots/actions/runs/27404326886

Related issue: https://github.com/elastic/observability-robots/issues/3863
