### PR TITLE
fix(workflows): grant actions:read for gh-aw lock workflow callers

### DIFF
--- a/.github/workflows/oblt-aw-agent-suggestions.yml
+++ b/.github/workflows/oblt-aw-agent-suggestions.yml
@@ -53,6 +53,7 @@ jobs:
   agent-suggestions:
     needs: [resolve-apm-assets]
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: read

--- a/.github/workflows/oblt-aw-autodoc.yml
+++ b/.github/workflows/oblt-aw-autodoc.yml
@@ -66,6 +66,7 @@ jobs:
   audit:
     needs: [resolve-apm-assets-audit]
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: read

--- a/.github/workflows/oblt-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/oblt-aw-duplicate-issue-detector.yml
@@ -44,6 +44,7 @@ jobs:
   duplicate-issue-detector:
     needs: [resolve-apm-assets]
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: read

--- a/.github/workflows/oblt-aw-event-issues.yml
+++ b/.github/workflows/oblt-aw-event-issues.yml
@@ -53,6 +53,7 @@ jobs:
         github.event_name == 'workflow_dispatch'
       )
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: read

--- a/.github/workflows/oblt-aw-event-schedule.yml
+++ b/.github/workflows/oblt-aw-event-schedule.yml
@@ -26,6 +26,7 @@ jobs:
     if: >-
       fromJSON(needs.prelude.outputs.proceed-by-workflow)['oblt-aw-agent-suggestions.yml'] == 'true'
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: read

--- a/docs/workflows/oblt-aw-duplicate-issue-detector.md
+++ b/docs/workflows/oblt-aw-duplicate-issue-detector.md
@@ -31,7 +31,7 @@ Permissions (job-level on the control-plane reusable; union mirrored on the clie
 | Job | Permissions |
 |-----|-------------|
 | `prelude` | `contents: read`, `issues: read` |
-| `duplicate-issue-detector` | `contents: read`, `issues: write`, `pull-requests: read` (matches `gh-aw-duplicate-issue-detector.lock.yml`) |
+| `duplicate-issue-detector` | `actions: read`, `contents: read`, `issues: write`, `pull-requests: read` (matches `gh-aw-duplicate-issue-detector.lock.yml`) |
 
 ## API / Interface
 


### PR DESCRIPTION
## Summary

- Add `actions: read` to jobs that call `gh-aw-*.lock.yml` workflows where the nested `activation` job requires it.
- Fix the `trigger-oblt-aw-schedule.yml` validation failure for agent-suggestions by aligning permissions on `oblt-aw-event-schedule.yml` and `oblt-aw-agent-suggestions.yml`.
- Apply the same least-privilege alignment to autodoc and duplicate-issue-detector routes and their event orchestrators.

## Test plan

- [x] `python3 scripts/validate_aw_workflow_prelude.py`
- [x] `python3 scripts/validate_aw_workflow_resolve_apm_assets.py`
- [x] `pytest tests/test_validate_aw_workflow_prelude.py tests/test_validate_aw_workflow_resolve_apm_assets.py`
- [x] Pre-commit hooks (yamllint, actionlint, yaml checks)

Fixes https://github.com/elastic/oblt-robot/actions/runs/27532482946

Related with https://github.com/elastic/observability-robots/issues/3614