### PR TITLE
fix(workflows): install APM packages via microsoft/apm-action

### DIFF
--- a/.github/workflows/aw-resolve-apm-assets.yml
+++ b/.github/workflows/aw-resolve-apm-assets.yml
@@ -128,32 +128,6 @@ jobs:
       - name: Install Python dependencies for resolver
         run: pip install -r _oblt-aw/requirements-runtime.txt
 
-      - name: Install APM CLI
-        if: >-
-          inputs.install-apm-packages &&
-          steps.detect.outputs.present == 'true'
-        env:
-          APM_VERSION: "v0.16.0"
-        run: |
-          set -euo pipefail
-          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-          ARCH="$(uname -m)"
-          case "${ARCH}" in
-            x86_64) ARCH="x86_64" ;;
-            arm64|aarch64) ARCH="arm64" ;;
-            *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;;
-          esac
-          TARBALL="apm-${OS}-${ARCH}.tar.gz"
-          BASE_URL="https://github.com/microsoft/apm/releases/download/${APM_VERSION}"
-          curl -fsSL "${BASE_URL}/${TARBALL}" -o "/tmp/${TARBALL}"
-          curl -fsSL "${BASE_URL}/${TARBALL}.sha256" -o "/tmp/${TARBALL}.sha256"
-          EXPECTED="$(awk '{print $1}' "/tmp/${TARBALL}.sha256")"
-          echo "${EXPECTED}  /tmp/${TARBALL}" | sha256sum -c
-          APM_DIR="${HOME}/.local/apm"
-          mkdir -p "${APM_DIR}"
-          tar -xzf "/tmp/${TARBALL}" -C "${APM_DIR}" --strip-components=1
-          echo "${APM_DIR}" >> "${GITHUB_PATH}"
-
       - name: Create ephemeral GitHub token for APM private dependencies
         id: create-apm-token
         if: >-
@@ -168,12 +142,10 @@ jobs:
         if: >-
           inputs.install-apm-packages &&
           steps.detect.outputs.present == 'true'
-        env:
-          GITHUB_APM_PAT: >-
-            ${{ steps.create-apm-token.outputs.token || secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          apm install
+        uses: microsoft/apm-action@e5650fb81c4b5965090a17bd1ed1956071e95d17 # v1.9.1
+        with:
+          apm-version: "0.20.0"
+          github-token: ${{ steps.create-apm-token.outputs.token || github.token }}
 
       - name: Resolve agentic assets from apm.yml
         id: resolve

--- a/docs/architecture/apm-agentic-assets.md
+++ b/docs/architecture/apm-agentic-assets.md
@@ -89,7 +89,7 @@ When the dashboard gate passes (`proceed == true`), each agent job’s preceding
 
 1. Checks out the **consumer** repository (caller context).
 2. Installs [`requirements-runtime.txt`](../../requirements-runtime.txt) with pip cache via `actions/setup-python`.
-3. Runs [`apm install`](https://microsoft.github.io/apm/) when `apm.yml` is present (installs declared skills, plugins, MCP servers, and other APM dependencies). Private GitHub packages use `ai-assets-token-policy` from `config/<org>/active-repositories.json` when set; otherwise the job `GITHUB_TOKEN` is forwarded as `GITHUB_APM_PAT` (see [aw-resolve-apm-assets](../workflows/aw-resolve-apm-assets.md)).
+3. Runs [`microsoft/apm-action`](https://github.com/microsoft/apm-action) when `apm.yml` is present (installs the APM CLI with tool-cache reuse and runs `apm install` for declared skills, plugins, MCP servers, and other APM dependencies). Private GitHub packages use `ai-assets-token-policy` from `config/<org>/active-repositories.json` when set; otherwise the job `GITHUB_TOKEN` is passed as `github-token` (see [aw-resolve-apm-assets](../workflows/aw-resolve-apm-assets.md)).
 4. Runs [`scripts/resolve_apm_agentic_assets.py`](../../scripts/resolve_apm_agentic_assets.py) with the compound workflow id (`org-key:workflow-id`) to select the org block and produce:
    - `resolved-additional-instructions`
    - `resolved-inputs-json` (merged platform + APM inputs)

--- a/docs/workflows/aw-resolve-apm-assets.md
+++ b/docs/workflows/aw-resolve-apm-assets.md
@@ -19,12 +19,12 @@ Wrappers that only gate or run scripts (for example `oblt-aw-security-detector.y
 | `control-plane-workflow` | string | (required) | Basename of the calling wrapper; used to resolve org key and registry workflow id for `x-oblt-aw.<org-key>.workflows.<id>` selection |
 | `platform-additional-instructions` | string | `""` | Control-plane baseline text for this agent invocation (prepended before repo APM instructions) |
 | `platform-inputs-json` | string | `"{}"` | JSON object of platform inputs; APM `inputs` override per key |
-| `install-apm-packages` | boolean | `true` | Run `apm install` when `apm.yml` is present |
+| `install-apm-packages` | boolean | `true` | Run [`microsoft/apm-action`](https://github.com/microsoft/apm-action) when `apm.yml` is present (installs the APM CLI and runs `apm install`) |
 
 Private GitHub dependencies use one of two auth paths during `apm install`:
 
-- When `ai-assets-token-policy` is set for the consumer repository in `config/<org>/active-repositories.json`, the workflow mints an ephemeral token via `elastic/oblt-actions/github/create-token@v1` and forwards it as `GITHUB_APM_PAT`.
-- When `ai-assets-token-policy` is empty, `GITHUB_APM_PAT` falls back to the job `GITHUB_TOKEN` (`contents: read`), which is sufficient for same-repository private path dependencies.
+- When `ai-assets-token-policy` is set for the consumer repository in `config/<org>/active-repositories.json`, the workflow mints an ephemeral token via `elastic/oblt-actions/github/create-token@v1` and passes it to `apm-action` as `github-token` (forwarded internally as `GITHUB_APM_PAT`).
+- When `ai-assets-token-policy` is empty, `github-token` falls back to the job `GITHUB_TOKEN` (`contents: read`), which is sufficient for same-repository private path dependencies.
 
 The `workflow-token-policy` field (exposed to route workflows as `shared-token-policy` via `aw-prelude`) is separate and covers agentic workflow `create-token` steps, not APM package clones.
 


### PR DESCRIPTION
## Summary

- Replace the manual APM CLI curl/tar install and shell `apm install` step in `aw-resolve-apm-assets.yml` with [`microsoft/apm-action`](https://github.com/microsoft/apm-action) v1.9.1 (SHA-pinned).
- Preserve existing private-dependency auth: ephemeral token via `create-token` when `ai-assets-token-policy` is set, otherwise `github.token`.
- Bump APM CLI from 0.16.0 to 0.20.0 (latest stable) and update workflow/architecture docs.

## Test plan

- [x] `python3 scripts/validate_aw_workflow_resolve_apm_assets.py`
- [x] `pytest tests/test_validate_aw_workflow_resolve_apm_assets.py`
- [x] Pre-commit hooks (yamllint, actionlint) passed on commit
- [ ] CI green on this PR
- [ ] Verify `aw-resolve-apm-assets` succeeds for a consumer repo with `apm.yml`

Related issue: https://github.com/elastic/observability-robots/issues/4626