### PR TITLE
Supersede duplicate SEC detector issues on new scan

### DIFF
--- a/.github/workflows/oblt-aw-event-issues.yml
+++ b/.github/workflows/oblt-aw-event-issues.yml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/aw-prelude.yml
     with:
       control-plane-workflows: >-
-        ["oblt-aw-issue-triage.yml","oblt-aw-duplicate-issue-detector.yml","oblt-aw-security-triage.yml","oblt-aw-security-fixer.yml","oblt-aw-resource-not-accessible-by-integration-triage.yml","oblt-aw-resource-not-accessible-by-integration-fixer.yml"]
+        ["oblt-aw-issue-triage.yml","oblt-aw-duplicate-issue-detector.yml","oblt-aw-security-issue-superseder.yml","oblt-aw-security-triage.yml","oblt-aw-security-fixer.yml","oblt-aw-resource-not-accessible-by-integration-triage.yml","oblt-aw-resource-not-accessible-by-integration-fixer.yml"]
       load-allowed-authors: true
 
   issue-triage:
@@ -71,6 +71,27 @@ jobs:
       shared-token-policy: ${{ needs.prelude.outputs.token-policy }}
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  security-issue-superseder:
+    needs: prelude
+    if: >-
+      fromJSON(needs.prelude.outputs.proceed-by-workflow)['oblt-aw-security-issue-superseder.yml'] == 'true' &&
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/detector/security')
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/oblt-aw-security-issue-superseder.yml
+    with:
+      shared-proceed: ${{ fromJSON(needs.prelude.outputs.proceed-by-workflow)['oblt-aw-security-issue-superseder.yml'] }}
+      shared-allowed-pr-authors-json: ${{ needs.prelude.outputs.allowed-pr-authors-json }}
+      shared-allowed-pr-authors-csv: ${{ needs.prelude.outputs.allowed-pr-authors-csv }}
+      shared-allowed-issue-authors-json: ${{ needs.prelude.outputs.allowed-issue-authors-json }}
+      shared-allowed-issue-authors-csv: ${{ needs.prelude.outputs.allowed-issue-authors-csv }}
+      shared-token-policy: ${{ needs.prelude.outputs.token-policy }}
 
   security-triage:
     needs: prelude

--- a/.github/workflows/oblt-aw-security-issue-superseder.yml
+++ b/.github/workflows/oblt-aw-security-issue-superseder.yml
@@ -1,0 +1,74 @@
+---
+name: Security Issue Superseder
+on:
+  workflow_call:
+    inputs:
+      shared-proceed:
+        description: Dashboard gate for this route from aw-prelude.
+        required: true
+        type: string
+      shared-allowed-pr-authors-json:
+        required: true
+        type: string
+      shared-allowed-pr-authors-csv:
+        required: true
+        type: string
+      shared-allowed-issue-authors-json:
+        required: true
+        type: string
+      shared-allowed-issue-authors-csv:
+        required: true
+        type: string
+      shared-token-policy:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+
+  supersede-security-issues:
+    if: >-
+      inputs.shared-proceed == 'true' &&
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw/detector/security')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout oblt-aw (supersession script)
+        uses: actions/checkout@v6
+        with:
+          repository: elastic/oblt-aw
+          ref: main
+          path: _oblt-aw
+          sparse-checkout: |
+            scripts/obs/supersede-security-issues.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Create ephemeral GitHub token (configured policy)
+        id: create-token-explicit
+        if: inputs.shared-token-policy != ''
+        uses: elastic/oblt-actions/github/create-token@v1
+        with:
+          token-policy: ${{ inputs.shared-token-policy }}
+
+      - name: Create ephemeral GitHub token (Vault auto policy)
+        id: create-token-auto
+        if: inputs.shared-token-policy == ''
+        uses: elastic/oblt-actions/github/create-token@v1
+
+      - name: Supersede older security detector issues
+        env:
+          GH_TOKEN: ${{ steps.create-token-explicit.outputs.token || steps.create-token-auto.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ALLOWED_BOT_AUTHORS: ${{ inputs.shared-allowed-issue-authors-csv }}
+        run: |
+          chmod +x _oblt-aw/scripts/obs/supersede-security-issues.sh
+          _oblt-aw/scripts/obs/supersede-security-issues.sh "${{ github.event.issue.number }}"

--- a/config/obs/workflow-registry.json
+++ b/config/obs/workflow-registry.json
@@ -74,6 +74,7 @@
       "control_plane_workflows": [
         "oblt-aw-security-detector.yml",
         "oblt-aw-security-fixer.yml",
+        "oblt-aw-security-issue-superseder.yml",
         "oblt-aw-security-triage.yml"
       ]
     },

--- a/docs/architecture/multi-org-agentic-workflows.md
+++ b/docs/architecture/multi-org-agentic-workflows.md
@@ -75,6 +75,7 @@ scripts/
     validateAutomergePr.ts                  # Automerge verify step
     security-scan.sh                        # Security detector scan driver
     create-security-issues.sh               # Open grouped SEC issues from findings
+    supersede-security-issues.sh            # Close older open SEC detector issues on new scan
     install_security_detector_tools.sh      # Tooling bootstrap for detector
   docs/
     issue-menu/                             # Docs AI issue menu (github-script modules)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -23,6 +23,7 @@ Specialized workflows:
 - [.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml](../../.github/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.yml)
 - [.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml](../../.github/workflows/oblt-aw-resource-not-accessible-by-integration-triage.yml)
 - [.github/workflows/oblt-aw-security-detector.yml](../../.github/workflows/oblt-aw-security-detector.yml)
+- [.github/workflows/oblt-aw-security-issue-superseder.yml](../../.github/workflows/oblt-aw-security-issue-superseder.yml)
 - [.github/workflows/oblt-aw-security-fixer.yml](../../.github/workflows/oblt-aw-security-fixer.yml)
 - [.github/workflows/oblt-aw-security-triage.yml](../../.github/workflows/oblt-aw-security-triage.yml)
 

--- a/docs/architecture/security-agent-architecture.md
+++ b/docs/architecture/security-agent-architecture.md
@@ -17,13 +17,16 @@ This document defines the architecture for proactive security bug hunting and re
 The security agent pipeline follows this flow:
 
 1. **Detector** — Scheduled or manually triggered. Scans code (shell scripts, workflow YAML) for security vulnerabilities. When it creates an issue (using the title prefix `[oblt-aw][security]`) for a finding, it must add the label `oblt-aw/detector/security` and include structured findings.
-2. **Triage** — Triggered on issues labeled `oblt-aw/detector/security`. Classifies using `oblt-aw/triage/security-*` (injection, secrets, supply-chain, least-privilege), `oblt-aw/triage/other`, or `oblt-aw/triage/needs-info`. Produces a resolution plan where applicable. When an issue is ready for automated fix, triage adds `oblt-aw/ai/fix-ready` (the fixer path requires this together with a `oblt-aw/triage/security-*` label).
-3. **Fixer** — Triggered on issues that have both `oblt-aw/triage/security-*` and `oblt-aw/ai/fix-ready`. Implements fixes per triage plan and opens draft PRs.
+2. **Superseder** — Triggered when a new detector issue is **opened**. Closes older open issues for the **same SEC rule** (deterministic script; see [oblt-aw-security-issue-superseder.md](../workflows/oblt-aw-security-issue-superseder.md)). Skips issues already in triage/fixer or with open non-bot fix PRs.
+3. **Triage** — Triggered on issues labeled `oblt-aw/detector/security`. Classifies using `oblt-aw/triage/security-*` (injection, secrets, supply-chain, least-privilege), `oblt-aw/triage/other`, or `oblt-aw/triage/needs-info`. Produces a resolution plan where applicable. When an issue is ready for automated fix, triage adds `oblt-aw/ai/fix-ready` (the fixer path requires this together with a `oblt-aw/triage/security-*` label).
+4. **Fixer** — Triggered on issues that have both `oblt-aw/triage/security-*` and `oblt-aw/ai/fix-ready`. Implements fixes per triage plan and opens draft PRs.
 
 ```mermaid
 flowchart TD
   A[Schedule / workflow_dispatch] --> B[Security Detector]
   B --> C[Creates issue + label oblt-aw/detector/security]
+  C --> S[Security Issue Superseder]
+  S --> C2[Closes older open issues same SEC id]
   C --> D[Security Triage]
   D --> E["oblt-aw/triage/security-*, other, or needs-info"]
   E --> F[oblt-aw/ai/fix-ready when ready to fix]
@@ -61,6 +64,7 @@ The detector targets the full ruleset in [docs/workflows/security-scanning-rules
 | Stage | ai-github-actions Workflow | Usage |
 |-------|----------------------------|-------|
 | **Detector** | None (code-scanning) | Custom job runs shellcheck, actionlint, zizmor, semgrep, and npm audit; creates issues. If a code-scanning agent is added later, oblt-aw can migrate to it. |
+| **Superseder** | None (shell script) | [`supersede-security-issues.sh`](../../scripts/obs/supersede-security-issues.sh) on `issues` `opened` for `oblt-aw/detector/security`; closes stale open issues per SEC id ([oblt-aw-security-issue-superseder.md](../workflows/oblt-aw-security-issue-superseder.md)). |
 | **Triage** | `gh-aw-issue-triage.lock.yml` | Triggered for issues labeled `oblt-aw/detector/security`; classifies with `oblt-aw/triage/security-*`, `oblt-aw/triage/other`, or `oblt-aw/triage/needs-info`; adds `oblt-aw/ai/fix-ready` when ready to fix. |
 | **Fixer** | `gh-aw-issue-fixer.lock.yml` | Triggered when a `oblt-aw/triage/security-*` label and `oblt-aw/ai/fix-ready` are present; security-specific instructions; least-privilege and env-indirection patterns. |
 
@@ -72,8 +76,9 @@ The detector targets the full ruleset in [docs/workflows/security-scanning-rules
 
 1. **Detector** — Workflow that checks out the caller repository and runs checks for currently implemented SEC-* rules (shellcheck, pattern scanners, optional ecosystem audits), with additional ruleset IDs tracked for future detector expansion.
 2. **Issues** — Created with prefix `[oblt-aw][security]` and label `oblt-aw/detector/security`.
-3. **Triage** — Runs on `oblt-aw/detector/security` issues; applies granular `oblt-aw/triage/security-*` labels; adds `oblt-aw/ai/fix-ready` when appropriate.
-4. **Fixer** — Produces draft PRs per triage plan (env indirection, pinning, permissions, and other remediations as specified).
+3. **Superseder** — Closes superseded open detector issues for the same SEC rule when a newer scan opens a replacement issue ([elastic/observability-robots#4424](https://github.com/elastic/observability-robots/issues/4424)).
+4. **Triage** — Runs on `oblt-aw/detector/security` issues; applies granular `oblt-aw/triage/security-*` labels; adds `oblt-aw/ai/fix-ready` when appropriate.
+5. **Fixer** — Produces draft PRs per triage plan (env indirection, pinning, permissions, and other remediations as specified).
 
 **Coverage:** The ruleset document defines full SEC-* coverage aligned with [elastic/observability-robots#3758](https://github.com/elastic/observability-robots/issues/3758), and the detector currently emits the subset listed in the ruleset overview/traceability sections. Token exposure via command-line args remains a documented class ([oblt-actions#500](https://github.com/elastic/oblt-actions/issues/500)).
 

--- a/docs/routing/security-routing.md
+++ b/docs/routing/security-routing.md
@@ -7,16 +7,18 @@ Client templates: `trigger-oblt-aw-security-*.yml` → matching `oblt-aw-securit
 Routed workflows (`oblt-aw-security-*`; registry id `security`):
 
 - [.github/workflows/oblt-aw-security-detector.yml](../../.github/workflows/oblt-aw-security-detector.yml)
+- [.github/workflows/oblt-aw-security-issue-superseder.yml](../../.github/workflows/oblt-aw-security-issue-superseder.yml)
 - [.github/workflows/oblt-aw-security-triage.yml](../../.github/workflows/oblt-aw-security-triage.yml)
 - [.github/workflows/oblt-aw-security-fixer.yml](../../.github/workflows/oblt-aw-security-fixer.yml)
 
-All three workflows use the same Control Plane dashboard gate: prelude allows `obs:security` when [workflow-registry.json](../../config/obs/workflow-registry.json) id `security` is enabled ([aw-prelude](../workflows/aw-prelude.md)).
+All four workflows use the same Control Plane dashboard gate: prelude allows `obs:security` when [workflow-registry.json](../../config/obs/workflow-registry.json) id `security` is enabled ([aw-prelude](../workflows/aw-prelude.md)).
 
 ## Usage
 
 Routing rules in `oblt-aw-security-*.yml` (issue routes follow the same label pattern as `resource-not-accessible-by-integration-*`):
 
 - **Detector** — `schedule` or `workflow_dispatch`.
+- **Superseder** — `issues` + `opened` when the issue has `oblt-aw/detector/security` (closes older open issues for the same SEC rule; see [docs/workflows/oblt-aw-security-issue-superseder.md](../workflows/oblt-aw-security-issue-superseder.md)).
 - **Triage** — `issues` + (`opened` and issue already has `oblt-aw/detector/security`) **or** (`labeled` and the label applied is `oblt-aw/detector/security`).
 - **Fixer** — `issues` + `labeled` with `oblt-aw/ai/fix-ready`, and the issue has at least one label matching `oblt-aw/triage/security-*`.
 
@@ -26,6 +28,13 @@ Routing rules in `oblt-aw-security-*.yml` (issue routes follow the same label pa
 
 - **Events**: `schedule`, `workflow_dispatch`
 - **Role**: Static scan of the repository; opens issues with label `oblt-aw/detector/security` for findings (see [docs/workflows/oblt-aw-security-detector.md](../workflows/oblt-aw-security-detector.md)).
+
+### Superseder
+
+- **Event**: `issues`
+- **Action**: `opened`
+- **Required label**: `oblt-aw/detector/security` on the **new** (canonical) issue
+- **Role**: Closes older open detector issues for the same SEC id; skips issues in triage/fixer and those with open non-bot fix PRs ([docs/workflows/oblt-aw-security-issue-superseder.md](../workflows/oblt-aw-security-issue-superseder.md)).
 
 ### Triage
 
@@ -61,5 +70,6 @@ The ingress uses `contains(join(github.event.issue.labels.*.name, ','), 'oblt-aw
 ## References
 
 - [docs/workflows/oblt-aw-security-detector.md](../workflows/oblt-aw-security-detector.md)
+- [docs/workflows/oblt-aw-security-issue-superseder.md](../workflows/oblt-aw-security-issue-superseder.md)
 - [docs/workflows/oblt-aw-security-triage.md](../workflows/oblt-aw-security-triage.md)
 - [docs/workflows/oblt-aw-security-fixer.md](../workflows/oblt-aw-security-fixer.md)

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -27,6 +27,7 @@ This section provides documentation for each workflow source in [.github/workflo
 - Resource Not Accessible by Integration fixer workflow: [docs/workflows/oblt-aw-resource-not-accessible-by-integration-fixer.md](oblt-aw-resource-not-accessible-by-integration-fixer.md)
 - Security scanning ruleset: [docs/workflows/security-scanning-ruleset.md](security-scanning-ruleset.md)
 - Security detector workflow: [docs/workflows/oblt-aw-security-detector.md](oblt-aw-security-detector.md)
+- Security issue superseder workflow: [docs/workflows/oblt-aw-security-issue-superseder.md](oblt-aw-security-issue-superseder.md)
 - Security triage workflow: [docs/workflows/oblt-aw-security-triage.md](oblt-aw-security-triage.md)
 - Security fixer workflow: [docs/workflows/oblt-aw-security-fixer.md](oblt-aw-security-fixer.md)
 - Security routing: [docs/routing/security-routing.md](../routing/security-routing.md)

--- a/docs/workflows/oblt-aw-client-template.md
+++ b/docs/workflows/oblt-aw-client-template.md
@@ -56,7 +56,7 @@ Full platform view (distribution, dashboard sync, before/after ingress): [archit
 | Client template | Triggers | Reusable workflow |
 |-----------------|----------|-------------------|
 | `trigger-oblt-aw-pull-request.yml` | `pull_request` (opened, synchronize, reopened, labeled) | `oblt-aw-event-pull-request.yml` → automerge, dependency-review |
-| `trigger-oblt-aw-issues.yml` | `issues` (opened, labeled), `workflow_dispatch` | `oblt-aw-event-issues.yml` → issue-triage, duplicate-issue-detector, security triage/fixer, resource triage/fixer |
+| `trigger-oblt-aw-issues.yml` | `issues` (opened, labeled), `workflow_dispatch` | `oblt-aw-event-issues.yml` → issue-triage, duplicate-issue-detector, security superseder/triage/fixer, resource triage/fixer |
 | `trigger-oblt-aw-issue-comment.yml` | `issue_comment` created | `oblt-aw-event-issue-comment.yml` → issue-fixer, mention-in-issue |
 | `trigger-oblt-aw-schedule.yml` | `schedule` (daily 06:00 UTC), `workflow_dispatch` | `oblt-aw-event-schedule.yml` → agent-suggestions, autodoc, security-detector, resource-not-accessible detector |
 | `trigger-oblt-aw-status.yml` | `status` (Buildkite failure only, job `if`) | `oblt-aw-event-status.yml` → estc-pr-buildkite-detective |

--- a/docs/workflows/oblt-aw-security-detector.md
+++ b/docs/workflows/oblt-aw-security-detector.md
@@ -26,6 +26,8 @@ Single job **scan**:
 5. Runs `_oblt-aw/scripts/obs/security-scan.sh` with argument `target`, which emits findings as `file|line|rule|severity|message` (actionlint + zizmor + semgrep + shellcheck + custom heuristics + npm audit, with per-file/line deduplication).
 6. When there are findings, creates an ephemeral token then runs `_oblt-aw/scripts/obs/create-security-issues.sh` to open issues in **the caller** (`github.repository`) with label `oblt-aw/detector/security`. Findings are **grouped by rule (SEC id)**: **one issue per rule** per run, not one issue per line. The issue **title** is `[oblt-aw][security] <SEC-xxx> — findings (<YYYY-MM-DD>)`, where the date is the analysis date (UTC calendar day; the workflow sets `SECURITY_SCAN_DATE` when creating issues). The **body** lists every occurrence for that rule (file, line, severity, message). The current issue-creation step does **not** emit `oblt-aw/severity/*` labels; severity is represented in the issue body and mapped in [Security Scanning Ruleset → Severity Levels](security-scanning-ruleset.md#severity-levels).
 
+Each new issue triggers the **issues** event orchestrator. When `obs:security` is enabled, [oblt-aw-security-issue-superseder.yml](../../.github/workflows/oblt-aw-security-issue-superseder.yml) runs [`supersede-security-issues.sh`](../../scripts/obs/supersede-security-issues.sh) to close older open issues for the same SEC id before triage proceeds on the canonical issue. See [oblt-aw-security-issue-superseder.md](oblt-aw-security-issue-superseder.md).
+
 Detector scripts are always taken from the public repository **`elastic/oblt-aw`** at ref **`main`** (no checkout token). Scheduled callers do not need a `workflow_call` input for the host ref.
 
 **Consumer example**:
@@ -70,4 +72,5 @@ Callers that trigger on a **schedule** cannot rely on `workflow_call` inputs for
 - Client template: [oblt-aw-client-template.md](oblt-aw-client-template.md) — registry id `security`
 - [Security agent architecture](../architecture/security-agent-architecture.md)
 - [Security scanning ruleset](security-scanning-ruleset.md)
+- [Security issue superseder](oblt-aw-security-issue-superseder.md)
 - [elastic/observability-robots#3758](https://github.com/elastic/observability-robots/issues/3758)

--- a/docs/workflows/oblt-aw-security-issue-superseder.md
+++ b/docs/workflows/oblt-aw-security-issue-superseder.md
@@ -1,0 +1,82 @@
+# Workflow: `oblt-aw-security-issue-superseder.yml`
+
+## Overview
+
+Source file: [.github/workflows/oblt-aw-security-issue-superseder.yml](../../.github/workflows/oblt-aw-security-issue-superseder.yml)
+
+Deterministic supersession for security detector issues. When a **new** issue is opened with label `oblt-aw/detector/security`, this workflow closes **older open** issues for the **same SEC rule** and retires linked bot fix PRs when safe.
+
+Implementation is a shell script ([`scripts/obs/supersede-security-issues.sh`](../../scripts/obs/supersede-security-issues.sh)); it does **not** call [elastic/ai-github-actions](https://github.com/elastic/ai-github-actions). See [elastic/observability-robots#4424](https://github.com/elastic/observability-robots/issues/4424).
+
+## Prerequisites
+
+- Invoked via `workflow_call` from [oblt-aw-event-issues.yml](../../.github/workflows/oblt-aw-event-issues.yml) (client template `trigger-oblt-aw-issues.yml`).
+- Dashboard gating uses registry id **`security`** (`obs:security`) — same compound id as detector, triage, and fixer.
+- Ephemeral GitHub token from [`elastic/oblt-actions/github/create-token@v1`](https://github.com/elastic/oblt-actions/tree/v1/github/create-token) (same pattern as the security detector).
+
+## Usage
+
+Ingress routes here when:
+
+- `github.event_name == 'issues'` and `github.event.action == 'opened'`, and
+- The opened issue includes label `oblt-aw/detector/security`, and
+- Prelude allows `oblt-aw-security-issue-superseder.yml` (via `obs:security`).
+
+Job **supersede-security-issues**:
+
+1. Checks out `scripts/obs/supersede-security-issues.sh` from [elastic/oblt-aw](https://github.com/elastic/oblt-aw) at ref `main`.
+2. Creates an ephemeral token when configured (Vault auto policy or repo `workflow-token-policy`).
+3. Runs the script with the **canonical** issue number (`github.event.issue.number`).
+
+### Supersession policy
+
+| Rule | Behavior |
+|------|----------|
+| **Equivalence** | Same **SEC id** parsed from title `[oblt-aw][security] SEC-XXX — findings (…)` and label `oblt-aw/detector/security` |
+| **Direction** | Newer issue (higher number) is canonical; only **older** open issues are candidates |
+| **Skip close** | Candidate has `oblt-aw/ai/fix-ready`, any `oblt-aw/triage/security-*`, `oblt-aw/triage/other`, or `oblt-aw/triage/needs-info` |
+| **Skip close** | Candidate has an **open** PR referencing it (`Fixes` / `Closes` / `Resolves #N`) authored by a login **not** in the issue allow-list |
+| **Close PR** | Open bot-authored PRs (allow-list from prelude) that reference a superseded issue are closed with a comment |
+
+On supersede, the script posts a comment on the older issue linking to the canonical issue, then closes it.
+
+## Configuration
+
+Permissions (job **supersede-security-issues**):
+
+| Permission | Purpose |
+|------------|---------|
+| `contents: read` | Sparse checkout of oblt-aw script |
+| `id-token: write` | OIDC for `create-token` |
+| `issues: write` | Comment and close superseded issues |
+| `pull-requests: write` | Close linked bot fix PRs |
+
+Environment passed to the script:
+
+| Variable | Source |
+|----------|--------|
+| `GITHUB_REPOSITORY` | Caller repository |
+| `GH_TOKEN` | Ephemeral token from `create-token` |
+| `ALLOWED_BOT_AUTHORS` | `shared-allowed-issue-authors-csv` from prelude |
+
+Set `DRY_RUN=1` locally to log actions without mutating GitHub.
+
+## API / Interface
+
+`workflow_call` contract (standard shared prelude inputs):
+
+- `shared-proceed` (required)
+- `shared-allowed-pr-authors-json` / `shared-allowed-pr-authors-csv` (required)
+- `shared-allowed-issue-authors-json` / `shared-allowed-issue-authors-csv` (required)
+- `shared-token-policy` (required; may be empty)
+
+No secrets are declared on this workflow.
+
+## References
+
+- Client template: [oblt-aw-client-template.md](oblt-aw-client-template.md) — registry id `security`
+- Script: [`scripts/obs/supersede-security-issues.sh`](../../scripts/obs/supersede-security-issues.sh)
+- Issue creation (detector): [`scripts/obs/create-security-issues.sh`](../../scripts/obs/create-security-issues.sh)
+- [Security agent architecture](../architecture/security-agent-architecture.md)
+- [Security routing](../routing/security-routing.md)
+- [elastic/observability-robots#4424](https://github.com/elastic/observability-robots/issues/4424)

--- a/scripts/obs/supersede-security-issues.sh
+++ b/scripts/obs/supersede-security-issues.sh
@@ -103,7 +103,7 @@ linked_pr_references_issue() {
   local issue_number="$1"
   local pr_json="$2"
   local haystack
-  haystack="$(jq -r '[.title, .body] | join("\n")' <<< "$pr_json" | tr '[:upper:]' '[:lower:]')"
+  haystack="$(jq -r '[.title // "", .body // ""] | join("\n")' <<< "$pr_json" | tr '[:upper:]' '[:lower:]')"
   [[ "$haystack" == *"fixes #${issue_number}"* ]] \
     || [[ "$haystack" == *"closes #${issue_number}"* ]] \
     || [[ "$haystack" == *"resolves #${issue_number}"* ]]

--- a/scripts/obs/supersede-security-issues.sh
+++ b/scripts/obs/supersede-security-issues.sh
@@ -95,8 +95,7 @@ find_open_linked_prs() {
   local search_query="repo:${repo} is:pr is:open \"#${issue_number}\""
   gh search prs "$search_query" \
     --json number,author,isDraft,title,body \
-    --limit 20 \
-    2>/dev/null || printf '[]\n'
+    --limit 20
 }
 
 linked_pr_references_issue() {

--- a/scripts/obs/supersede-security-issues.sh
+++ b/scripts/obs/supersede-security-issues.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Copyright 2026-2027 Elasticsearch B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Closes older open security detector issues superseded by a newer issue for the same SEC rule.
+# Usage: supersede-security-issues.sh <canonical_issue_number>
+#
+# Environment:
+#   GITHUB_REPOSITORY (required)
+#   GH_TOKEN (required unless DRY_RUN=1)
+#   ALLOWED_BOT_AUTHORS (optional, comma-separated logins; default: github-actions[bot])
+#   DRY_RUN (optional, set to 1 to log actions without mutating GitHub)
+set -euo pipefail
+
+readonly DETECTOR_LABEL="oblt-aw/detector/security"
+readonly TITLE_PREFIX="[oblt-aw][security]"
+readonly BLOCK_LABELS=(
+  "oblt-aw/ai/fix-ready"
+  "oblt-aw/triage/security-injection"
+  "oblt-aw/triage/security-secrets"
+  "oblt-aw/triage/security-supply-chain"
+  "oblt-aw/triage/security-least-privilege"
+  "oblt-aw/triage/other"
+  "oblt-aw/triage/needs-info"
+)
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+is_dry_run() {
+  [[ "${DRY_RUN:-0}" == "1" ]]
+}
+
+parse_sec_id_from_title() {
+  local title="$1"
+  if [[ "$title" =~ ^\[oblt-aw\]\[security\]\ (SEC-[0-9]+)[[:space:]] ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+issue_has_label() {
+  local labels_json="$1"
+  local wanted="$2"
+  jq -e --arg label "$wanted" '[.labels[].name] | index($label) != null' <<< "$labels_json" >/dev/null
+}
+
+issue_has_block_label() {
+  local labels_json="$1"
+  local label
+  for label in "${BLOCK_LABELS[@]}"; do
+    if issue_has_label "$labels_json" "$label"; then
+      printf '%s\n' "$label"
+      return 0
+    fi
+  done
+  return 1
+}
+
+author_is_allowed_bot() {
+  local author="$1"
+  local csv="$2"
+  local item normalized item_normalized
+  normalized="$(printf '%s' "$author" | tr '[:upper:]' '[:lower:]')"
+  IFS=',' read -ra items <<< "$csv"
+  for item in "${items[@]}"; do
+    item="${item#"${item%%[![:space:]]*}"}"
+    item="${item%"${item##*[![:space:]]}"}"
+    [[ -z "$item" ]] && continue
+    item_normalized="$(printf '%s' "$item" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$item_normalized" == "$normalized" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+find_open_linked_prs() {
+  local issue_number="$1"
+  local repo="$2"
+  local search_query="repo:${repo} is:pr is:open \"#${issue_number}\""
+  gh search prs "$search_query" \
+    --json number,author,isDraft,title,body \
+    --limit 20 \
+    2>/dev/null || printf '[]\n'
+}
+
+linked_pr_references_issue() {
+  local issue_number="$1"
+  local pr_json="$2"
+  local haystack
+  haystack="$(jq -r '[.title, .body] | join("\n")' <<< "$pr_json" | tr '[:upper:]' '[:lower:]')"
+  [[ "$haystack" == *"fixes #${issue_number}"* ]] \
+    || [[ "$haystack" == *"closes #${issue_number}"* ]] \
+    || [[ "$haystack" == *"resolves #${issue_number}"* ]]
+}
+
+supersession_comment() {
+  local canonical="$1"
+  local sec_id="$2"
+  cat <<EOF
+Superseded by #${canonical} — a newer security detector issue replaces this report for the same rule (**${sec_id}**).
+
+This issue is closed automatically. See #${canonical} for the latest findings and analysis date.
+EOF
+}
+
+pr_supersession_comment() {
+  local canonical="$1"
+  local issue_number="$2"
+  cat <<EOF
+Closing as superseded: issue #${issue_number} was replaced by #${canonical} from a newer security detector scan.
+EOF
+}
+
+close_superseded_issue() {
+  local issue_number="$1"
+  local canonical="$2"
+  local sec_id="$3"
+  local repo="$4"
+  local comment
+  comment="$(supersession_comment "$canonical" "$sec_id")"
+
+  if is_dry_run; then
+    log "[dry-run] would comment and close issue #${issue_number} (superseded by #${canonical})"
+    return 0
+  fi
+
+  gh issue comment "$issue_number" --repo "$repo" --body "$comment"
+  gh issue close "$issue_number" --repo "$repo" --reason "not planned"
+}
+
+close_superseded_pr() {
+  local pr_number="$1"
+  local canonical="$2"
+  local issue_number="$3"
+  local repo="$4"
+  local comment
+  comment="$(pr_supersession_comment "$canonical" "$issue_number")"
+
+  if is_dry_run; then
+    log "[dry-run] would close PR #${pr_number} (linked to superseded issue #${issue_number})"
+    return 0
+  fi
+
+  gh pr close "$pr_number" --repo "$repo" --comment "$comment"
+}
+
+process_superseded_issue() {
+  local issue_number="$1"
+  local canonical="$2"
+  local sec_id="$3"
+  local repo="$4"
+  local allowed_bot_authors="$5"
+  local issue_json block_label linked_prs pr_json pr_number pr_author
+
+  issue_json="$(gh issue view "$issue_number" --repo "$repo" --json number,title,state,labels)"
+  if [[ "$(jq -r '.state' <<< "$issue_json")" != "OPEN" ]]; then
+    log "Skipping #${issue_number}: not open"
+    return 0
+  fi
+
+  if block_label="$(issue_has_block_label "$issue_json")"; then
+    log "Skipping #${issue_number}: block label ${block_label}"
+    return 0
+  fi
+
+  linked_prs="$(find_open_linked_prs "$issue_number" "$repo")"
+  while IFS= read -r pr_json; do
+    [[ -z "$pr_json" ]] && continue
+    if ! linked_pr_references_issue "$issue_number" "$pr_json"; then
+      continue
+    fi
+    pr_author="$(jq -r '.author.login // empty' <<< "$pr_json")"
+    if [[ -n "$pr_author" ]] && ! author_is_allowed_bot "$pr_author" "$allowed_bot_authors"; then
+      log "Skipping #${issue_number}: open non-bot PR by ${pr_author}"
+      return 0
+    fi
+  done < <(jq -c '.[]' <<< "$linked_prs")
+
+  close_superseded_issue "$issue_number" "$canonical" "$sec_id" "$repo"
+
+  while IFS= read -r pr_json; do
+    [[ -z "$pr_json" ]] && continue
+    if ! linked_pr_references_issue "$issue_number" "$pr_json"; then
+      continue
+    fi
+    pr_number="$(jq -r '.number' <<< "$pr_json")"
+    pr_author="$(jq -r '.author.login // empty' <<< "$pr_json")"
+    if [[ -n "$pr_author" ]] && author_is_allowed_bot "$pr_author" "$allowed_bot_authors"; then
+      close_superseded_pr "$pr_number" "$canonical" "$issue_number" "$repo"
+    fi
+  done < <(jq -c '.[]' <<< "$linked_prs")
+}
+
+main() {
+  local canonical_issue="${1:?canonical issue number required}"
+  local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+  local allowed_bot_authors="${ALLOWED_BOT_AUTHORS:-github-actions[bot]}"
+  local canonical_json canonical_title sec_id candidates issue_number row
+
+  export DRY_RUN="${DRY_RUN:-0}"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    log "gh CLI is required"
+    exit 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    log "jq is required"
+    exit 1
+  fi
+
+  if is_dry_run; then
+    log "[dry-run] supersede-security-issues for canonical issue #${canonical_issue}"
+  fi
+
+  canonical_json="$(gh issue view "$canonical_issue" --repo "$repo" --json number,title,state,labels)"
+  if [[ "$(jq -r '.state' <<< "$canonical_json")" != "OPEN" ]]; then
+    log "Canonical issue #${canonical_issue} is not open; nothing to do"
+    exit 0
+  fi
+
+  if ! issue_has_label "$canonical_json" "$DETECTOR_LABEL"; then
+    log "Canonical issue #${canonical_issue} lacks ${DETECTOR_LABEL}; skipping"
+    exit 0
+  fi
+
+  canonical_title="$(jq -r '.title' <<< "$canonical_json")"
+  if ! sec_id="$(parse_sec_id_from_title "$canonical_title")"; then
+    log "Canonical issue #${canonical_issue} title is not a security detector issue; skipping"
+    exit 0
+  fi
+
+  candidates="$(gh issue list \
+    --repo "$repo" \
+    --label "$DETECTOR_LABEL" \
+    --state open \
+    --limit 500 \
+    --json number,title \
+    | jq -c --argjson canonical "$canonical_issue" --arg sec "$sec_id" --arg prefix "$TITLE_PREFIX" '
+        .[]
+        | select(.number < $canonical)
+        | select(.title | startswith($prefix + " " + $sec))
+      ')"
+
+  if [[ -z "$candidates" ]]; then
+    log "No older open issues to supersede for ${sec_id}"
+    exit 0
+  fi
+
+  while IFS= read -r row; do
+    [[ -z "$row" ]] && continue
+    issue_number="$(jq -r '.number' <<< "$row")"
+    process_superseded_issue "$issue_number" "$canonical_issue" "$sec_id" "$repo" "$allowed_bot_authors"
+  done <<< "$candidates"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/tests/test_supersede_security_issues.py
+++ b/tests/test_supersede_security_issues.py
@@ -1,0 +1,62 @@
+"""Tests for scripts/obs/supersede-security-issues.sh helpers."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+import pytest
+
+SCRIPT = (
+    pathlib.Path(__file__).parent.parent
+    / "scripts"
+    / "obs"
+    / "supersede-security-issues.sh"
+)
+
+
+def _bash(function_call: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", f'source "{SCRIPT}" && {function_call}'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_parse_sec_id_from_title_matches_detector_format() -> None:
+    title = "[oblt-aw][security] SEC-030 — findings (2026-06-18)"
+    result = _bash(f'parse_sec_id_from_title "{title}"')
+    assert result.returncode == 0
+    assert result.stdout.strip() == "SEC-030"
+
+
+def test_parse_sec_id_from_title_rejects_unrelated_titles() -> None:
+    result = _bash('parse_sec_id_from_title "Bug: something else"')
+    assert result.returncode == 1
+    assert result.stdout.strip() == ""
+
+
+@pytest.mark.parametrize(
+    ("author", "allowed", "expected"),
+    [
+        ("github-actions[bot]", "github-actions[bot],copilot", True),
+        ("Copilot", "github-actions[bot],copilot", True),
+        ("human-user", "github-actions[bot],copilot", False),
+    ],
+)
+def test_author_is_allowed_bot(author: str, allowed: str, expected: bool) -> None:
+    result = _bash(f'author_is_allowed_bot "{author}" "{allowed}"')
+    assert result.returncode == (0 if expected else 1)
+
+
+def test_linked_pr_references_issue_detects_fixes_keyword() -> None:
+    pr_json = '{"title":"Fix SEC-030","body":"Fixes #42 with env indirection"}'
+    result = _bash(f"linked_pr_references_issue 42 '{pr_json}'")
+    assert result.returncode == 0
+
+
+def test_linked_pr_references_issue_ignores_unrelated_prs() -> None:
+    pr_json = '{"title":"Unrelated","body":"No issue link here"}'
+    result = _bash(f"linked_pr_references_issue 42 '{pr_json}'")
+    assert result.returncode == 1

--- a/tests/test_supersede_security_issues.py
+++ b/tests/test_supersede_security_issues.py
@@ -56,6 +56,12 @@ def test_linked_pr_references_issue_detects_fixes_keyword() -> None:
     assert result.returncode == 0
 
 
+def test_linked_pr_references_issue_handles_null_body() -> None:
+    pr_json = '{"title":"Fixes #42","body":null}'
+    result = _bash(f"linked_pr_references_issue 42 '{pr_json}'")
+    assert result.returncode == 0
+
+
 def test_linked_pr_references_issue_ignores_unrelated_prs() -> None:
     pr_json = '{"title":"Unrelated","body":"No issue link here"}'
     result = _bash(f"linked_pr_references_issue 42 '{pr_json}'")


### PR DESCRIPTION
## Summary

- Add `scripts/obs/supersede-security-issues.sh` to close older open `oblt-aw/detector/security` issues for the same SEC rule when a newer detector issue is opened.
- Wire a new `oblt-aw-security-issue-superseder.yml` route into the issues event orchestrator, gated by the `obs:security` dashboard id.
- Skip supersession when triage/fix-ready labels are present or when a linked open fix PR was authored by a non-bot user; close bot-linked PRs when the superseded issue is retired.

## Test plan

- [x] `python3 -m pytest tests/test_supersede_security_issues.py tests/test_workflow_registry.py tests/test_evaluate_workflow_gates.py`
- [x] `python3 scripts/validate_aw_workflow_prelude.py`
- [x] pre-commit hooks on commit (shellcheck, yamllint, workflow lint)
- [ ] Manual: open two `[oblt-aw][security] SEC-XXX` detector issues in a pilot repo and confirm the older one is closed with a supersession comment when the newer issue opens

Related issue: https://github.com/elastic/observability-robots/issues/4424