### PR TITLE
Fix security superseder PR lookup without Search API

### DIFF
--- a/docs/workflows/oblt-aw-security-issue-superseder.md
+++ b/docs/workflows/oblt-aw-security-issue-superseder.md
@@ -35,7 +35,7 @@ Job **supersede-security-issues**:
 | **Equivalence** | Same **SEC id** parsed from title `[oblt-aw][security] SEC-XXX — findings (…)` and label `oblt-aw/detector/security` |
 | **Direction** | Newer issue (higher number) is canonical; only **older** open issues are candidates |
 | **Skip close** | Candidate has `oblt-aw/ai/fix-ready`, any `oblt-aw/triage/security-*`, `oblt-aw/triage/other`, or `oblt-aw/triage/needs-info` |
-| **Skip close** | Candidate has an **open** PR referencing it (`Fixes` / `Closes` / `Resolves #N`) authored by a login **not** in the issue allow-list |
+| **Skip close** | Candidate has an **open** PR with closing keywords (`Fixes` / `Closes` / `Resolves #N`) authored by a login **not** in the issue allow-list (resolved via issue cross-references, not Search API) |
 | **Close PR** | Open bot-authored PRs (allow-list from prelude) that reference a superseded issue are closed with a comment |
 
 On supersede, the script posts a comment on the older issue linking to the canonical issue, then closes it.

--- a/scripts/obs/supersede-security-issues.sh
+++ b/scripts/obs/supersede-security-issues.sh
@@ -92,10 +92,24 @@ author_is_allowed_bot() {
 find_open_linked_prs() {
   local issue_number="$1"
   local repo="$2"
-  local search_query="repo:${repo} is:pr is:open \"#${issue_number}\""
-  gh search prs "$search_query" \
-    --json number,author,isDraft,title,body \
-    --limit 20
+  local pr_number pr_json results="[]"
+
+  # Use issue cross-references (Issues/PRs API) instead of gh search prs, which
+  # requires the Search API scope that ephemeral workflow tokens often lack.
+  while IFS= read -r pr_number; do
+    [[ -z "$pr_number" ]] && continue
+    pr_json="$(gh pr view "$pr_number" --repo "$repo" --json number,author,isDraft,title,body,state)"
+    if [[ "$(jq -r '.state' <<< "$pr_json")" != "OPEN" ]]; then
+      continue
+    fi
+    results="$(jq -c --argjson pr "$pr_json" '. + [$pr]' <<< "$results")"
+  done < <(
+    gh issue view "$issue_number" --repo "$repo" \
+      --json closedByPullRequestsReferences \
+      | jq -r '.closedByPullRequestsReferences[]?.number // empty'
+  )
+
+  printf '%s\n' "$results"
 }
 
 linked_pr_references_issue() {


### PR DESCRIPTION
## Summary

- Replace `gh search prs` in `supersede-security-issues.sh` with issue cross-references (`closedByPullRequestsReferences`) plus `gh pr view`, avoiding the GitHub Search API that ephemeral workflow tokens lack.
- Document the linked-PR lookup behavior in the security superseder workflow doc.

## Test plan

- [x] `python3 -m pytest tests/test_supersede_security_issues.py -v`
- [x] `DRY_RUN=1 GITHUB_REPOSITORY=elastic/oblt-aw scripts/obs/supersede-security-issues.sh 1249` completes without Search API permission errors (including candidates such as #1231 that previously failed)

Fixes https://github.com/elastic/oblt-aw/actions/runs/27813761317/job/82309952974

Related issue: https://github.com/elastic/observability-robots/issues/4424
