### PR TITLE
Make obs agentic workflows opt-in by default

### DIFF
--- a/.github/workflows/get-enabled-workflows.yml
+++ b/.github/workflows/get-enabled-workflows.yml
@@ -12,7 +12,7 @@ on:
       effective-raw:
         description: >-
           Pre-normalization string from the dashboard read ('', '[]', or '["id",...]');
-          empty means no open dashboard issue (ingress enables all workflows).
+          empty means no open dashboard issue (no workflows enabled).
         value: ${{ jobs['read-dashboard'].outputs['effective-raw'] }}
   workflow_dispatch:
 

--- a/.github/workflows/sync-control-plane-dashboard.yml
+++ b/.github/workflows/sync-control-plane-dashboard.yml
@@ -9,6 +9,13 @@ on:
       - config/**/active-repositories.json
       - .github/workflows/sync-control-plane-dashboard.yml
   workflow_dispatch:
+    inputs:
+      force-sync-defaults:
+        description: >-
+          Reset every dashboard checkbox to the current registry default_enabled
+          value (overwrites user-edited checkbox state on all target repositories).
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -83,4 +90,10 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.create-token.outputs.token }}
           TARGET_REPO: ${{ matrix.repository }}
-        run: python scripts/sync_control_plane_dashboard.py --repo "$TARGET_REPO"
+          FORCE_SYNC_DEFAULTS: ${{ github.event_name == 'workflow_dispatch' && inputs.force-sync-defaults && 'true' || 'false' }}
+        run: |
+          args=(--repo "$TARGET_REPO")
+          if [ "$FORCE_SYNC_DEFAULTS" = "true" ]; then
+            args+=(--force-sync-defaults)
+          fi
+          python scripts/sync_control_plane_dashboard.py "${args[@]}"

--- a/config/obs/workflow-registry.json
+++ b/config/obs/workflow-registry.json
@@ -6,7 +6,7 @@
       "name": "Agent Suggestions",
       "description": "Suggests agentic workflows and improvements for the repository based on analysis of current setup.",
       "maturity": "early-adoption",
-      "default_enabled": true,
+      "default_enabled": false,
       "control_plane_workflows": ["oblt-aw-agent-suggestions.yml"]
     },
     {
@@ -14,7 +14,7 @@
       "name": "Automated Documentation",
       "description": "Analyzes documentation for gaps, outdated content, and inconsistencies; creates issues and PRs to improve docs.",
       "maturity": "early-adoption",
-      "default_enabled": true,
+      "default_enabled": false,
       "control_plane_workflows": ["oblt-aw-autodoc.yml"]
     },
     {
@@ -22,7 +22,7 @@
       "name": "Automerge",
       "description": "Enables auto-merge for allowed bot PRs (same authors as dependency-review) with oblt-aw/ai/merge-ready when validation and approval gates pass; GitHub enforces required checks at merge time.",
       "maturity": "early-adoption",
-      "default_enabled": true,
+      "default_enabled": false,
       "control_plane_workflows": ["oblt-aw-automerge.yml"]
     },
     {
@@ -30,7 +30,7 @@
       "name": "Dependency Review",
       "description": "Analyzes dependency-update PRs from bots, applies merge-ready labels when criteria are met.",
       "maturity": "early-adoption",
-      "default_enabled": true,
+      "default_enabled": false,
       "control_plane_workflows": ["oblt-aw-dependency-review.yml"]
     },
     {

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -150,11 +150,11 @@ The Control Plane Dashboard provides a self-service UI for repository users to o
 1. **Dashboard sync** (`sync-control-plane-dashboard`): Reads per-org `config/<org-key>/workflow-registry.json` and `active-repositories.json`; creates or updates the **single** dashboard issue in each target repository with sections per org; pins the issue when possible
 2. **User edit:** Users check or uncheck workflow checkboxes in the dashboard issue (no config file; no PRs on checkbox edits)
 3. **Runtime check** (`get-enabled-workflows`): When a `oblt-aw-*` workflow runs, prelude invokes this reusable workflow first. It parses the dashboard (or `effective-raw` is empty when no issue exists) and emits normalized `enabled-workflows`.
-4. **Prelude gating:** Downstream jobs use `needs.prelude.outputs.proceed`; empty `effective-raw` → all workflows; empty array → none; non-empty array → only listed compound ids
+4. **Prelude gating:** Downstream jobs use `needs.prelude.outputs.proceed`; empty `effective-raw` or empty `enabled-workflows` → none; non-empty `enabled-workflows` → only listed compound ids
 
 ### Opt-in / Opt-out
 
-- **No dashboard exists:** All workflows are activated by default
+- **No dashboard exists:** All workflows are deactivated
 - **Dashboard exists, all unchecked:** All workflows are deactivated
 - **Dashboard exists, some checked:** Only checked workflows are executed
 

--- a/docs/onboarding/adopting-agentic-workflows.md
+++ b/docs/onboarding/adopting-agentic-workflows.md
@@ -4,7 +4,7 @@
 
 **Adopting** a new workflow means: it is **defined in the remote control plane** (`elastic/oblt-aw` — reusable `oblt-aw-*` workflows with [aw-prelude](../workflows/aw-prelude.md)), then **consumer repositories** run it through a distributed **`trigger-oblt-aw-<workflow-id>.yml`** client template that calls `elastic/oblt-aw/.github/workflows/oblt-aw-<name>.yml@main`.
 
-You **cannot** meaningfully “enable” a workflow in a repository until it **exists in that org’s** [`workflow-registry.json`](../../config/obs/workflow-registry.json), the **client template and `oblt-aw-*` wrapper** exist, and [sync-control-plane-dashboard](../workflows/sync-control-plane-dashboard.md) has rendered it on the Control Plane Dashboard (or until prelude sees no dashboard and treats the full catalog as enabled).
+You **cannot** meaningfully “enable” a workflow in a repository until it **exists in that org’s** [`workflow-registry.json`](../../config/obs/workflow-registry.json), the **client template and `oblt-aw-*` wrapper** exist, and [sync-control-plane-dashboard](../workflows/sync-control-plane-dashboard.md) has rendered it on the Control Plane Dashboard. A workflow runs only when its checkbox is checked on that dashboard (or after sync creates the dashboard and you enable it).
 
 Each **organization** owns `config/<org-key>/` (for example `config/obs/`): [`workflow-registry.json`](../../config/obs/workflow-registry.json) and [`active-repositories.json`](../../config/obs/active-repositories.json). Gating uses compound ids `org-key:workflow-id` ([`get-enabled-workflows`](../workflows/get-enabled-workflows.md), [Control Plane Dashboard format](../operations/control-plane-dashboard-format.md), [multi-org design](../architecture/multi-org-agentic-workflows.md)).
 
@@ -61,7 +61,7 @@ Each **organization** owns `config/<org-key>/` (for example `config/obs/`): [`wo
 
 | Dashboard state | Effect |
 |-----------------|--------|
-| No open dashboard issue (`effective-raw` empty) | All registry workflows enabled |
+| No open dashboard issue (`effective-raw` empty) | None |
 | Dashboard exists, all unchecked | None |
 | Dashboard exists, some checked | Only checked `org-key:workflow-id` values |
 

--- a/docs/operations/control-plane-dashboard-format.md
+++ b/docs/operations/control-plane-dashboard-format.md
@@ -10,7 +10,7 @@ This document defines the structure and format of the OBLT AW Control Plane Dash
 
 The Control Plane Dashboard is a **single** GitHub issue per consumer repository that lists all available agentic workflows, **grouped by owning org** (see `config/<org-key>/` in this repository). Users enable or disable each workflow by checking task-list items. When the client workflow runs, the ingress (`get-enabled-workflows`) looks for an open issue labeled `oblt-aw/dashboard` and sets gating from `effective-raw` and normalized `enabled-workflows`:
 
-- **No such issue** → `effective-raw` is empty (ingress enables **all** workflows by default).
+- **No such issue** → `effective-raw` is empty; no agentic workflows run until sync creates the dashboard and workflows are enabled.
 - **Dashboard exists** → normalized outputs are a JSON array string: `[]` if **no** checkboxes are checked (no agentic workflows run), or `["org:workflow-id", ...]` for only the checked workflows, using the **canonical compound id** (colon-separated).
 
 There is no config file (no `.github/oblt-aw-config.json`), no PRs when users toggle checkboxes, and no `issues.edited` trigger—the dashboard is read at runtime each time the client runs.
@@ -140,7 +140,7 @@ To extract enabled workflows from the issue body (when a dashboard issue exists)
    emit `obs:workflow-id`.
 4. Emit a compact JSON array string of those compound ids. That string is what `get-enabled-workflows` writes to the `enabled-workflows` output when the dashboard issue exists.
 
-**No open dashboard issue:** The job outputs `[]` for the normalized `enabled-workflows` output (same as an empty selection). The ingress uses `effective-raw` (empty string when no dashboard) to treat that as “all workflows enabled.”
+**No open dashboard issue:** The job outputs `[]` for the normalized `enabled-workflows` output (same as an empty selection). Prelude treats empty `effective-raw` the same way: no workflows run.
 
 ---
 
@@ -161,7 +161,7 @@ The dashboard MUST include clear instructions. Recommended text:
 - **Enable a workflow:** Check the checkbox next to the workflow. `get-enabled-workflows` will include its compound id in `enabled-workflows` at runtime.
 - **Disable a workflow:** Uncheck the checkbox. `get-enabled-workflows` will exclude it from `enabled-workflows` at runtime.
 - **When changes apply:** The dashboard is read at runtime when the client runs. No config file; no PRs on checkbox edits.
-- **Default behavior:** No dashboard → all workflows activated; dashboard exists with all unchecked → all workflows deactivated; dashboard exists with some checked → only checked workflows executed.
+- **Default behavior:** No dashboard or dashboard with all unchecked → no workflows run; dashboard exists with some checked → only checked workflows executed.
 
 ---
 

--- a/docs/operations/control-plane-dashboard.md
+++ b/docs/operations/control-plane-dashboard.md
@@ -48,9 +48,9 @@ The ingress dashboard stage excludes the workflow from `enabled-workflows` at ru
 
 1. **You edit the issue** — Check or uncheck one or more workflow checkboxes (no immediate action; no PRs)
 2. **Client runs** — On the next trigger (schedule, workflow_dispatch, pull_request, etc.), the client workflow starts
-3. **`get-enabled-workflows` runs inside the ingress** — If there is no open dashboard issue, `effective-raw` is empty and normalized `enabled-workflows` is `[]` (ingress enables all workflows). Otherwise it fetches the issue via API, parses checkboxes (`^- [x] <!-- oblt-aw:<org-key>:<workflow-id> -->` at line start; legacy `obs` lines without an org segment are accepted), and writes normalized `enabled-workflows` as a JSON array string (`[]` or `["org:workflow-id", ...]`).
+3. **`get-enabled-workflows` runs inside the ingress** — If there is no open dashboard issue, `effective-raw` is empty and normalized `enabled-workflows` is `[]` (no workflows run). Otherwise it fetches the issue via API, parses checkboxes (`^- [x] <!-- oblt-aw:<org-key>:<workflow-id> -->` at line start; legacy `obs` lines without an org segment are accepted), and writes normalized `enabled-workflows` as a JSON array string (`[]` or `["org:workflow-id", ...]`).
 4. **Ingress gating** — The ingress uses `enabled-workflows` and `effective-raw` from `get-enabled-workflows` to gate downstream jobs.
-5. **Ingress gates execution** — Empty string → all workflows; `[]` → none; non-empty array → only listed compound ids. See [Default Behavior](#default-behavior).
+5. **Ingress gates execution** — Empty `effective-raw` or `enabled-workflows == []` → none; non-empty `enabled-workflows` → only listed compound ids. See [Default Behavior](#default-behavior).
 
 ---
 
@@ -58,7 +58,7 @@ The ingress dashboard stage excludes the workflow from `enabled-workflows` at ru
 
 | Dashboard state | Result |
 |-----------------|--------|
-| **No dashboard exists** | All workflows are activated by default |
+| **No dashboard exists** | All workflows are deactivated |
 | **Dashboard exists, all checkboxes unchecked** | All workflows are deactivated |
 | **Dashboard exists, some checkboxes checked** | Only checked workflows are executed |
 

--- a/docs/operations/workflow-maturity.md
+++ b/docs/operations/workflow-maturity.md
@@ -50,6 +50,6 @@ Maturity is set in each org’s [workflow-registry.json](../../config/obs/workfl
 - `maturity`: one of `stable`, `early-adoption`, or `experimental`
 - `default_enabled`: default checkbox state used by dashboard sync when a workflow is not yet present in an existing dashboard issue body
 
-`default_enabled` does not override user-edited dashboard checkbox state. It defines the initial state for newly introduced workflow IDs until users change them in the dashboard issue.
+`default_enabled` does not override user-edited dashboard checkbox state. It defines the initial state for newly introduced workflow IDs until users change them in the dashboard issue. All Observability (`config/obs/`) workflows use `default_enabled: false` (opt-in).
 
 Future enhancement: maturity could be derived automatically from metrics (e.g., successful execution ratio, proposed actions taken).

--- a/docs/operations/workflow-maturity.md
+++ b/docs/operations/workflow-maturity.md
@@ -50,6 +50,6 @@ Maturity is set in each org’s [workflow-registry.json](../../config/obs/workfl
 - `maturity`: one of `stable`, `early-adoption`, or `experimental`
 - `default_enabled`: default checkbox state used by dashboard sync when a workflow is not yet present in an existing dashboard issue body
 
-`default_enabled` does not override user-edited dashboard checkbox state. It defines the initial state for newly introduced workflow IDs until users change them in the dashboard issue. All Observability (`config/obs/`) workflows use `default_enabled: false` (opt-in).
+`default_enabled` does not override user-edited dashboard checkbox state during normal dashboard sync runs. It defines the initial state for newly introduced workflow IDs until users change them in the dashboard issue (unless `force-sync-defaults` is used to reset checkboxes). All Observability (`config/obs/`) workflows use `default_enabled: false` (opt-in).
 
 Future enhancement: maturity could be derived automatically from metrics (e.g., successful execution ratio, proposed actions taken).

--- a/docs/routing/dependency-review-routing.md
+++ b/docs/routing/dependency-review-routing.md
@@ -18,7 +18,7 @@ Ingress routes to dependency review when all conditions are true:
   - `Dependabot`
   - `Renovate`
   - `elastic-vault-github-plugin-prod[bot]`
-- Dashboard gate passes for registry id `dependency-review` (`enabled-workflows` contains `obs:dependency-review` when `effective-raw` is non-empty).
+- Dashboard gate passes for registry id `dependency-review` (`enabled-workflows` contains `obs:dependency-review`).
 
 For dashboard gate semantics (`get-enabled-workflows` and `enabled-workflows`), see [docs/workflows/aw-prelude.md](../workflows/aw-prelude.md).
 

--- a/docs/routing/resource-not-accessible-by-integration-routing.md
+++ b/docs/routing/resource-not-accessible-by-integration-routing.md
@@ -24,7 +24,7 @@ Routing rules from ingress:
   - issue contains label `oblt-aw/triage/res-not-accessible-by-integration`
   -> fixer
 
-All three routes (detector, triage, fixer) also require the shared dashboard gate to pass: `enabled-workflows` must contain `obs:resource-not-accessible-by-integration` when `effective-raw` is non-empty.
+All three routes (detector, triage, fixer) also require the shared dashboard gate to pass: `enabled-workflows` must contain `obs:resource-not-accessible-by-integration`.
 
 For dashboard gate semantics (`get-enabled-workflows` and `enabled-workflows`), see [docs/workflows/aw-prelude.md](../workflows/aw-prelude.md).
 

--- a/docs/workflows/aw-prelude.md
+++ b/docs/workflows/aw-prelude.md
@@ -24,7 +24,7 @@ APM asset resolution (`apm install`, `apm.yml` merge) is **not** part of the pre
 | Output | Description |
 |--------|-------------|
 | `proceed-by-workflow` | JSON map of workflow basename → `true`/`false` proceed flags |
-| `effective-raw` | Raw dashboard read (`''` means all workflows enabled) |
+| `effective-raw` | Raw dashboard read (`''` means no open dashboard issue) |
 | `enabled-workflows` | Normalized JSON array of compound ids |
 | `allowed-pr-authors-json` / `allowed-pr-authors-csv` | PR allow list (empty when not loaded) |
 | `allowed-issue-authors-json` / `allowed-issue-authors-csv` | Issue allow list (empty when not loaded) |
@@ -32,7 +32,7 @@ APM asset resolution (`apm install`, `apm.yml` merge) is **not** part of the pre
 
 ### Gating rule
 
-- `effective-raw` empty → all listed routes proceed
+- `effective-raw` empty → no listed routes proceed
 - Otherwise each route proceeds only when its registry-resolved compound id is in `enabled-workflows`
 
 ## References

--- a/docs/workflows/get-enabled-workflows.md
+++ b/docs/workflows/get-enabled-workflows.md
@@ -30,7 +30,7 @@ Called by ingress:
 
 Semantics used by ingress:
 
-- `effective-raw == ''`: no open dashboard issue exists; ingress treats all registry workflows as enabled.
+- `effective-raw == ''`: no open dashboard issue exists; gated workflows do not run.
 - `effective-raw != ''` and `enabled-workflows == []`: dashboard exists but nothing is selected; gated workflows do not run.
 - `effective-raw != ''` and non-empty `enabled-workflows`: only listed compound ids (`org:workflow-id`) are enabled.
 

--- a/docs/workflows/oblt-aw-duplicate-issue-detector.md
+++ b/docs/workflows/oblt-aw-duplicate-issue-detector.md
@@ -15,7 +15,7 @@ Reusable wrapper that calls the locked duplicate-issue-detector workflow in [ela
 Ingress routes here when:
 
 - `github.event_name == 'issues'` and `github.event.action == 'opened'`, or `github.event_name == 'workflow_dispatch'`, and
-- Dashboard gating allows `duplicate-issue-detector` (or no dashboard issue is present, so all workflows are enabled).
+- Dashboard gate passes for registry id `duplicate-issue-detector` (`enabled-workflows` contains `obs:duplicate-issue-detector`).
 
 The job `duplicate-issue-detector` calls:
 

--- a/docs/workflows/oblt-aw-estc-pr-buildkite-detective.md
+++ b/docs/workflows/oblt-aw-estc-pr-buildkite-detective.md
@@ -18,7 +18,7 @@ Ingress routes here when:
 - `github.event_name == 'status'`,
 - `github.event.state == 'failure'`, and
 - `github.event.context` contains `buildkite`, and
-- Dashboard gating allows `estc-pr-buildkite-detective` (or no dashboard issue is present, so all workflows are enabled).
+- Dashboard gate passes for registry id `estc-pr-buildkite-detective` (`enabled-workflows` contains `obs:estc-pr-buildkite-detective`).
 
 The job `estc-pr-buildkite-detective` calls:
 

--- a/docs/workflows/oblt-aw-issue-fixer.md
+++ b/docs/workflows/oblt-aw-issue-fixer.md
@@ -24,7 +24,7 @@ Ingress routes here when:
 - `startsWith(github.event.comment.body, '/ai implement')`, and
 - `github.event.comment.author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`, and
 - issue labels do not match the specialized security or resource-not-accessible fixer routes, and
-- dashboard gating allows `obs:issue-fixer` (or no dashboard issue is present, so all workflows are enabled).
+- Dashboard gate passes for registry id `issue-fixer` (`enabled-workflows` contains `obs:issue-fixer`).
 
 The job `run` calls:
 

--- a/docs/workflows/oblt-aw-issue-triage.md
+++ b/docs/workflows/oblt-aw-issue-triage.md
@@ -15,7 +15,7 @@ Reusable wrapper that calls the locked generic issue-triage workflow in [elastic
 Ingress routes here when:
 
 - `github.event_name == 'issues'` and `github.event.action == 'opened'`, and
-- Dashboard gating allows `issue-triage` (or no dashboard issue is present, so all workflows are enabled).
+- Dashboard gate passes for registry id `issue-triage` (`enabled-workflows` contains `obs:issue-triage`).
 
 The job `issue-triage` calls:
 

--- a/docs/workflows/oblt-aw-mention-in-issue.md
+++ b/docs/workflows/oblt-aw-mention-in-issue.md
@@ -19,7 +19,7 @@ Ingress routes here when:
 - `startsWith(github.event.comment.body, '/ai')`, and
 - comment does not start with `/ai implement` (reserved for the generic issue-fixer route), and
 - `github.event.comment.author_association` is one of `OWNER`, `MEMBER`, or `COLLABORATOR`, and
-- Dashboard gating allows `mention-in-issue` (or no dashboard issue is present, so all workflows are enabled).
+- Dashboard gate passes for registry id `mention-in-issue` (`enabled-workflows` contains `obs:mention-in-issue`).
 
 Comment prefix and author-association checks are enforced in `oblt-aw-mention-in-issue.yml` after prelude.
 

--- a/docs/workflows/sync-control-plane-dashboard.md
+++ b/docs/workflows/sync-control-plane-dashboard.md
@@ -20,21 +20,28 @@ Triggers:
 - `push` to `main` when any of these paths change:
   - `config/**/workflow-registry.json` and `config/**/active-repositories.json` (per-org trees)
   - [.github/workflows/sync-control-plane-dashboard.yml](../../.github/workflows/sync-control-plane-dashboard.yml)
-- `workflow_dispatch`
+- `workflow_dispatch` with optional input `force-sync-defaults` (boolean, default `false`)
 
 *Note: Editing the dashboard issue does not trigger this workflow. Dashboard opt-in/opt-out is read at runtime by the ingress (`get-enabled-workflows`); there is no `issues.edited` trigger.*
 
 Execution:
 
 1. **prepare-repos job:** Builds repos matrix from the union of org active-repository lists via [scripts/build_repos_matrix.py](../../scripts/build_repos_matrix.py); outputs JSON for matrix strategy
-2. **sync-dashboard job:** Matrix job (one job per repo); each invokes `scripts/sync_control_plane_dashboard.py --repo <owner/repo>`:
+2. **sync-dashboard job:** Matrix job (one job per repo); each invokes `scripts/sync_control_plane_dashboard.py --repo <owner/repo>` (and `--force-sync-defaults` when the dispatch input is `true`):
     - Search for existing open issue with label `oblt-aw/dashboard`
     - Create or update the issue with title `[oblt-aw] Control Plane Dashboard`, body merged from each applicable org registry (sections per org, three-part checkbox markers)
     - Pin the issue via `gh issue pin` (if limit of 3 pins reached, log and continue)
 
+### `force-sync-defaults` (workflow_dispatch)
+
+Set `force-sync-defaults: true` when manually running the workflow to **reset every checkbox** on all target dashboards to the current `default_enabled` value from each org’s `workflow-registry.json`. This overwrites user-edited checkbox state. Use after changing registry defaults (for example switching obs workflows to opt-in) to roll out the new baseline across active repositories.
+
+Regular `push`-triggered runs and dispatches with `force-sync-defaults: false` preserve existing checkbox state.
+
 ### `scripts/sync_control_plane_dashboard.py` runtime contract
 
 - `--repo OWNER/REPO` is required. Invalid values that are not in `owner/repo` format fail with exit code `1`.
+- `--force-sync-defaults` is optional. When set, every checkbox is rebuilt from registry `default_enabled` instead of preserving user-edited state from the existing dashboard body.
 - Authentication is required via `GH_TOKEN` or `GITHUB_TOKEN`. If neither is set, the script fails with exit code `1`.
 - The target repository must be listed in at least one `config/<org-key>/active-repositories.json`. If it is not present in any org config, the script fails with exit code `1` and does not create or update an issue.
 
@@ -43,6 +50,7 @@ Minimal local invocation example:
 ```bash
 export GH_TOKEN="<github-token-with-issue-write-permissions>"
 python3 scripts/sync_control_plane_dashboard.py --repo elastic/oblt-aw
+python3 scripts/sync_control_plane_dashboard.py --repo elastic/oblt-aw --force-sync-defaults
 ```
 
 Expected error behavior examples:
@@ -58,7 +66,7 @@ python3 scripts/sync_control_plane_dashboard.py --repo elastic/not-in-active-rep
 `default_enabled` behavior:
 
 - Used when building checkbox state for workflows that are not present in an existing dashboard body.
-- Existing checkbox state in the dashboard issue remains authoritative and is preserved during updates.
+- Existing checkbox state in the dashboard issue remains authoritative and is preserved during updates (unless `force-sync-defaults` is used).
 - For newly added workflows in `workflow-registry.json`, `default_enabled` determines the initial checkbox state until users edit that workflow's checkbox.
 
 ## Configuration

--- a/scripts/evaluate_workflow_gates.py
+++ b/scripts/evaluate_workflow_gates.py
@@ -37,7 +37,7 @@ def _proceed_for_compound_id(
     effective_raw: str, enabled_workflows_json: str, compound_id: str
 ) -> bool:
     if not effective_raw:
-        return True
+        return False
     enabled = json.loads(enabled_workflows_json)
     if not isinstance(enabled, list):
         raise ValueError("enabled-workflows must be a JSON array")
@@ -85,7 +85,7 @@ def main() -> int:
     parser.add_argument(
         "--effective-raw",
         default="",
-        help="Raw dashboard read ('' means all workflows enabled)",
+        help="Raw dashboard read ('' means no dashboard issue; no workflows enabled)",
     )
     parser.add_argument(
         "--enabled-workflows",

--- a/scripts/get_enabled_workflows.py
+++ b/scripts/get_enabled_workflows.py
@@ -133,7 +133,7 @@ def main() -> None:
         raw = "[]"
     elif body is None:
         raw = ""
-        print("No dashboard issue found, defaulting to all workflows enabled")
+        print("No dashboard issue found, no workflows will run")
     else:
         enabled = parse_enabled_ids_from_body(body)
         if enabled == "[]":

--- a/scripts/sync_control_plane_dashboard.py
+++ b/scripts/sync_control_plane_dashboard.py
@@ -24,8 +24,9 @@ Sync Control Plane Dashboard issue for a single repository.
 4. Pin issue via gh issue pin; if pin fails (e.g. 3 already pinned), log and continue
 
 On every run: title and table format are updated to current spec; user's enabled
-state is preserved per compound ``org:workflow-id``. Legacy two-part markers map
-to the ``obs`` org.
+state is preserved per compound ``org:workflow-id`` unless ``--force-sync-defaults``
+is set, in which case every checkbox is reset from registry ``default_enabled``.
+Legacy two-part markers map to the ``obs`` org.
 
 Invoked per-repo by the sync-control-plane-dashboard workflow matrix.
 
@@ -138,14 +139,16 @@ def org_config_dirs_for_target_repo(config_dir: Path, target_repo: str) -> list[
 def build_dashboard_body(
     org_sections: list[tuple[str, str, list[dict[str, Any]]]],
     existing_body: str | None,
+    *,
+    force_sync_defaults: bool = False,
 ) -> str:
     """Build one dashboard body with a Markdown section per org.
 
     Each ``org_sections`` item is ``(org_key, section_heading, workflows)``.
     Preserves enabled/disabled state from ``existing_body`` for compound ids and
-    legacy two-part ``obs`` markers.
+    legacy two-part ``obs`` markers unless ``force_sync_defaults`` is true.
     """
-    parsed = parse_checkbox_state(existing_body)
+    parsed = {} if force_sync_defaults else parse_checkbox_state(existing_body)
     lines = [
         "## Control Plane Dashboard",
         "",
@@ -181,7 +184,7 @@ def build_dashboard_body(
         for wf in workflows:
             wf_id = wf["id"]
             name = wf.get("name", wf_id)
-            default = wf.get("default_enabled", True)
+            default = wf.get("default_enabled", False)
             cmp_key = compound_workflow_key(org_key, wf_id)
             enabled = parsed.get(cmp_key, default)
             checkbox = "- [x]" if enabled else "- [ ]"
@@ -298,6 +301,8 @@ def sync_repo(
     repo: str,
     token: str,
     org_sections: list[tuple[str, str, list[dict[str, Any]]]],
+    *,
+    force_sync_defaults: bool = False,
 ) -> None:
     """Sync dashboard issue for one repository."""
     owner, _, repo_name = repo.partition("/")
@@ -305,11 +310,23 @@ def sync_repo(
         logger.error("Invalid repo format: %s", repo)
         return
     existing = find_dashboard_issue(owner, repo_name, token)
-    body = build_dashboard_body(org_sections, existing["body"] if existing else None)
+    body = build_dashboard_body(
+        org_sections,
+        existing["body"] if existing else None,
+        force_sync_defaults=force_sync_defaults,
+    )
     if existing:
         issue_number = existing["number"]
         update_issue(owner, repo_name, issue_number, token, body)
-        logger.info("Updated dashboard issue #%s in %s", issue_number, repo)
+        if force_sync_defaults:
+            logger.info(
+                "Updated dashboard issue #%s in %s (checkboxes reset to "
+                "registry default_enabled)",
+                issue_number,
+                repo,
+            )
+        else:
+            logger.info("Updated dashboard issue #%s in %s", issue_number, repo)
     else:
         created = create_issue(owner, repo_name, token, body)
         issue_number = created["number"]
@@ -327,6 +344,14 @@ def main() -> int:
         metavar="OWNER/REPO",
         required=True,
         help="Repository to sync (e.g. elastic/oblt-aw)",
+    )
+    parser.add_argument(
+        "--force-sync-defaults",
+        action="store_true",
+        help=(
+            "Reset every dashboard checkbox to registry default_enabled, "
+            "overwriting user-edited state"
+        ),
     )
     args = parser.parse_args()
 
@@ -356,7 +381,12 @@ def main() -> int:
         logger.warning("No workflows in org registries for %s", args.repo)
 
     try:
-        sync_repo(args.repo, token, org_sections)
+        sync_repo(
+            args.repo,
+            token,
+            org_sections,
+            force_sync_defaults=args.force_sync_defaults,
+        )
     except Exception as e:
         logger.exception("Failed to sync %s: %s", args.repo, e)
         return 1

--- a/tests/test_evaluate_workflow_gates.py
+++ b/tests/test_evaluate_workflow_gates.py
@@ -51,7 +51,7 @@ def config_dir(tmp_path: pathlib.Path) -> pathlib.Path:
     return tmp_path / "config"
 
 
-def test_all_enabled_when_no_dashboard(config_dir: pathlib.Path) -> None:
+def test_no_workflows_when_no_dashboard(config_dir: pathlib.Path) -> None:
     result = evaluate_gates(
         config_dir,
         ["oblt-aw-automerge.yml", "oblt-aw-dependency-review.yml"],
@@ -59,8 +59,8 @@ def test_all_enabled_when_no_dashboard(config_dir: pathlib.Path) -> None:
         enabled_workflows_json="[]",
     )
     assert result == {
-        "oblt-aw-automerge.yml": "true",
-        "oblt-aw-dependency-review.yml": "true",
+        "oblt-aw-automerge.yml": "false",
+        "oblt-aw-dependency-review.yml": "false",
     }
 
 

--- a/tests/test_sync_control_plane_dashboard.py
+++ b/tests/test_sync_control_plane_dashboard.py
@@ -148,6 +148,30 @@ class TestBuildDashboardBody:
         assert "- [ ]" in wf_a_line
         assert "- [x]" in wf_b_line
 
+    def test_force_sync_defaults_overwrites_existing_checkbox_state(self) -> None:
+        workflows = [
+            {
+                "id": "wf-a",
+                "name": "A",
+                "description": "Desc",
+                "default_enabled": False,
+            },
+            {"id": "wf-b", "name": "B", "description": "Desc", "default_enabled": True},
+        ]
+        existing = (
+            "- [x] <!-- oblt-aw:obs:wf-a --> A\n- [ ] <!-- oblt-aw:obs:wf-b --> B"
+        )
+        body = scpd.build_dashboard_body(
+            _obs_section(workflows),
+            existing,
+            force_sync_defaults=True,
+        )
+        lines = body.split("\n")
+        wf_a_line = next(line for line in lines if "oblt-aw:obs:wf-a" in line)
+        wf_b_line = next(line for line in lines if "oblt-aw:obs:wf-b" in line)
+        assert "- [ ]" in wf_a_line
+        assert "- [x]" in wf_b_line
+
     def test_uses_default_enabled_when_workflow_not_in_existing_body(self) -> None:
         workflows = [
             {


### PR DESCRIPTION
## Summary
- Set all Observability (`config/obs/`) registry entries to `default_enabled: false` and align dashboard sync fallback to opt-in.
- Standardize runtime gating so a missing dashboard behaves like an empty selection: no obs workflows run until explicitly enabled on the Control Plane Dashboard.
- Add `force-sync-defaults` (`workflow_dispatch` input and `--force-sync-defaults` script flag) to reset existing dashboard checkboxes from current registry defaults across all active repositories.

## Test plan
- [x] `pytest tests/test_evaluate_workflow_gates.py tests/test_sync_control_plane_dashboard.py tests/test_get_enabled_workflows.py tests/test_workflow_registry.py` (33 passed)
- [ ] After merge, run **Sync Control Plane Dashboard** manually with `force-sync-defaults: true` to roll out unchecked baselines to consumer repos
- [ ] Verify a consumer repo with no dashboard does not run obs workflows until sync creates the dashboard and workflows are checked

Related issue: https://github.com/elastic/observability-robots/issues/4692