### PR TITLE
fix(workflows): validate reusable-workflow caller permissions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
       - name: Validate gh-aw-* workflows call resolve-agentic-assets
         run: python scripts/validate_aw_workflow_resolve_agentic_assets.py
 
+      - name: Validate reusable-workflow caller permissions
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/validate_aw_workflow_permissions.py
+
   typescript-tests:
     name: TypeScript tests
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-aw-ai-menu.yml
+++ b/.github/workflows/docs-aw-ai-menu.yml
@@ -159,6 +159,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      copilot-requests: write
       issues: write
       pull-requests: write
     uses: elastic/docs-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v1
@@ -185,6 +186,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      copilot-requests: write
       discussions: write
       issues: write
       pull-requests: write

--- a/.github/workflows/docs-aw-pr-ai-menu.yml
+++ b/.github/workflows/docs-aw-pr-ai-menu.yml
@@ -186,6 +186,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      copilot-requests: write
       issues: write
       pull-requests: write
     uses: elastic/docs-actions/.github/workflows/gh-aw-docs-review.lock.yml@v1

--- a/.github/workflows/oblt-aw-duplicate-issue-detector.yml
+++ b/.github/workflows/oblt-aw-duplicate-issue-detector.yml
@@ -45,6 +45,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      discussions: write
       issues: write
       pull-requests: read
       copilot-requests: write

--- a/.github/workflows/oblt-aw-event-issues.yml
+++ b/.github/workflows/oblt-aw-event-issues.yml
@@ -50,6 +50,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      discussions: write
       id-token: write
       issues: write
       pull-requests: read

--- a/docs/workflows/oblt-aw-duplicate-issue-detector.md
+++ b/docs/workflows/oblt-aw-duplicate-issue-detector.md
@@ -30,7 +30,7 @@ Permissions (job-level on the control-plane reusable; union mirrored on the clie
 | Job | Permissions |
 |-----|-------------|
 | `prelude` | `contents: read`, `issues: read` |
-| `duplicate-issue-detector` | `actions: read`, `contents: read`, `issues: write`, `pull-requests: read` (matches `gh-aw-duplicate-issue-detector.lock.yml`) |
+| `duplicate-issue-detector` | `actions: read`, `contents: read`, `discussions: write`, `issues: write`, `pull-requests: read`, `copilot-requests: write` (matches `gh-aw-duplicate-issue-detector.lock.yml`) |
 
 ## API / Interface
 

--- a/scripts/validate_aw_workflow_permissions.py
+++ b/scripts/validate_aw_workflow_permissions.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright 2026-2027 Elasticsearch B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Validate reusable-workflow caller job permissions against callee requirements.
+
+For every job that calls a reusable workflow, the caller job must grant at least
+the maximum permission scope required by any job in the callee workflow, including
+nested reusable workflows (for example gh-aw-* lock files in elastic/ai-github-actions).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from workflow_permissions import (
+    WorkflowPermissionResolver,
+    effective_job_permissions,
+    is_reusable_workflow_job,
+    parse_reusable_workflow_uses,
+    permission_deficits,
+)
+
+WORKFLOWS_DIR = pathlib.Path(".github/workflows")
+
+
+def list_workflow_files() -> list[pathlib.Path]:
+    if not WORKFLOWS_DIR.is_dir():
+        raise FileNotFoundError(f"Missing directory: {WORKFLOWS_DIR}")
+    return sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(WORKFLOWS_DIR.glob("*.yaml"))
+
+
+def validate_workflow_file(
+    path: pathlib.Path,
+    resolver: WorkflowPermissionResolver,
+) -> list[str]:
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(workflow, dict):
+        return [f"{path}: workflow file must be a mapping"]
+
+    errors: list[str] = []
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return errors
+
+    root_permissions = workflow.get("permissions")
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict) or not is_reusable_workflow_job(job):
+            continue
+
+        uses = job.get("uses")
+        if not isinstance(uses, str):
+            continue
+
+        workflow_ref = parse_reusable_workflow_uses(uses)
+        if workflow_ref is None:
+            continue
+
+        caller_permissions = effective_job_permissions(root_permissions, job)
+        try:
+            required_permissions = resolver.callee_requirements(workflow_ref)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            errors.append(f"{path}: job '{job_id}' cannot resolve callee {uses}: {exc}")
+            continue
+
+        deficits = permission_deficits(caller_permissions, required_permissions)
+        for scope, caller_level, required_level in deficits:
+            errors.append(
+                f"{path}: job '{job_id}' calls {uses} but grants "
+                f"{scope}: {caller_level or 'none'} while callee requires "
+                f"{scope}: {required_level}"
+            )
+
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    workflow_files = list_workflow_files()
+    if not workflow_files:
+        print("No workflow files found to validate.", file=sys.stderr)
+        return 1
+
+    resolver = WorkflowPermissionResolver(WORKFLOWS_DIR)
+    reusable_call_count = 0
+
+    for path in workflow_files:
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        jobs: dict[str, Any] = (
+            workflow.get("jobs", {}) if isinstance(workflow, dict) else {}
+        )
+        reusable_call_count += sum(
+            1
+            for job in jobs.values()
+            if isinstance(job, dict) and is_reusable_workflow_job(job)
+        )
+        errors.extend(validate_workflow_file(path, resolver))
+
+    if errors:
+        print("reusable workflow permission validation failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Validated {len(workflow_files)} workflow file(s); "
+        f"{reusable_call_count} reusable-workflow call(s) have aligned permissions."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workflow_permissions.py
+++ b/scripts/workflow_permissions.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# Copyright 2026-2027 Elasticsearch B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Helpers for comparing GitHub Actions workflow permission scopes."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+PERMISSION_LEVELS = {"read": 1, "write": 2}
+
+REUSABLE_WORKFLOW_USES = re.compile(
+    r"^\.?/?\.github/workflows/.+\.ya?ml$|"
+    r"^[^/]+/[^/]+/\.github/workflows/.+\.ya?ml$",
+    re.IGNORECASE,
+)
+
+REUSABLE_WORKFLOW_REF = re.compile(
+    r"^(?P<location>\.?/?\.github/workflows/[^@]+\.ya?ml|"
+    r"(?P<owner>[^/]+)/(?P<repo>[^/]+)/\.github/workflows/[^@]+\.ya?ml)"
+    r"(?:@(?P<ref>.+))?$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ReusableWorkflowRef:
+    owner: str | None
+    repo: str | None
+    workflow_path: str
+    ref: str | None
+    raw: str
+
+
+def parse_reusable_workflow_uses(uses: str) -> ReusableWorkflowRef | None:
+    uses = uses.strip().split("#", 1)[0].strip()
+    if not REUSABLE_WORKFLOW_USES.match(uses.split("@", 1)[0]):
+        return None
+
+    match = REUSABLE_WORKFLOW_REF.match(uses)
+    if not match:
+        return None
+
+    location = match.group("location")
+    if location.startswith("./.github/workflows/") or location.startswith(
+        ".github/workflows/"
+    ):
+        workflow_path = location.removeprefix("./")
+        return ReusableWorkflowRef(
+            owner=None,
+            repo=None,
+            workflow_path=workflow_path,
+            ref=match.group("ref"),
+            raw=uses,
+        )
+
+    owner = match.group("owner")
+    repo = match.group("repo")
+    workflow_path = location.split(f"{owner}/{repo}/", 1)[1]
+    return ReusableWorkflowRef(
+        owner=owner,
+        repo=repo,
+        workflow_path=workflow_path,
+        ref=match.group("ref"),
+        raw=uses,
+    )
+
+
+def parse_permissions_block(permissions: Any) -> dict[str, str]:
+    if permissions is None:
+        return {}
+    if permissions == {}:
+        return {}
+    if not isinstance(permissions, dict):
+        raise ValueError(f"unsupported permissions block: {permissions!r}")
+    return {str(scope): str(level).lower() for scope, level in permissions.items()}
+
+
+def effective_job_permissions(
+    workflow_permissions: Any,
+    job: dict[str, Any],
+) -> dict[str, str]:
+    root = parse_permissions_block(workflow_permissions)
+    job_permissions = job.get("permissions", "__unset__")
+    if job_permissions == "__unset__":
+        return dict(root)
+    if job_permissions == {}:
+        return dict(root)
+    return parse_permissions_block(job_permissions)
+
+
+def merge_max_permissions(
+    left: dict[str, str],
+    right: dict[str, str],
+) -> dict[str, str]:
+    merged = dict(left)
+    for scope, level in right.items():
+        if scope not in merged:
+            merged[scope] = level
+            continue
+        if PERMISSION_LEVELS[level] > PERMISSION_LEVELS[merged[scope]]:
+            merged[scope] = level
+    return merged
+
+
+def permission_deficits(
+    caller: dict[str, str],
+    required: dict[str, str],
+) -> list[tuple[str, str, str]]:
+    deficits: list[tuple[str, str, str]] = []
+    for scope, required_level in sorted(required.items()):
+        caller_level = caller.get(scope, "none")
+        if PERMISSION_LEVELS.get(caller_level, 0) < PERMISSION_LEVELS.get(
+            required_level, 0
+        ):
+            deficits.append((scope, caller_level, required_level))
+    return deficits
+
+
+def is_reusable_workflow_job(job: dict[str, Any]) -> bool:
+    uses = job.get("uses")
+    return isinstance(uses, str) and parse_reusable_workflow_uses(uses) is not None
+
+
+class WorkflowPermissionResolver:
+    """Resolve reusable workflow YAML and compute permission ceilings."""
+
+    def __init__(
+        self,
+        workflows_dir: Path,
+        *,
+        local_owner: str = "elastic",
+        local_repo: str = "oblt-aw",
+        fetch_remote_workflow: Any | None = None,
+    ) -> None:
+        self.workflows_dir = workflows_dir
+        self.local_owner = local_owner
+        self.local_repo = local_repo
+        self._cache: dict[str, dict[str, Any]] = {}
+        self._requirements_cache: dict[str, dict[str, str]] = {}
+        self._fetch_remote_workflow = fetch_remote_workflow or self._default_fetch
+
+    def resolve(self, workflow_ref: ReusableWorkflowRef) -> dict[str, Any]:
+        cache_key = self._cache_key(workflow_ref)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        if self._is_local_ref(workflow_ref):
+            path = self.workflows_dir.parent.parent / workflow_ref.workflow_path
+            if not path.is_file():
+                raise FileNotFoundError(f"missing local workflow: {path}")
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        else:
+            owner = workflow_ref.owner or ""
+            repo = workflow_ref.repo or ""
+            ref = workflow_ref.ref or "main"
+            text = self._fetch_remote_workflow(
+                owner, repo, workflow_ref.workflow_path, ref
+            )
+            data = yaml.safe_load(text)
+
+        if not isinstance(data, dict):
+            raise ValueError(f"workflow is not a mapping: {workflow_ref.raw}")
+
+        self._cache[cache_key] = data
+        return data
+
+    def callee_requirements(self, workflow_ref: ReusableWorkflowRef) -> dict[str, str]:
+        cache_key = self._cache_key(workflow_ref)
+        if cache_key in self._requirements_cache:
+            return self._requirements_cache[cache_key]
+
+        workflow = self.resolve(workflow_ref)
+        required = self._workflow_requirements(workflow)
+        self._requirements_cache[cache_key] = required
+        return required
+
+    def _workflow_requirements(self, workflow: dict[str, Any]) -> dict[str, str]:
+        required: dict[str, str] = {}
+        jobs = workflow.get("jobs")
+        if not isinstance(jobs, dict):
+            return required
+
+        root_permissions = workflow.get("permissions")
+        for job in jobs.values():
+            if not isinstance(job, dict):
+                continue
+            effective = effective_job_permissions(root_permissions, job)
+            required = merge_max_permissions(required, effective)
+
+            uses = job.get("uses")
+            if isinstance(uses, str):
+                nested_ref = parse_reusable_workflow_uses(uses)
+                if nested_ref is not None:
+                    nested_required = self.callee_requirements(nested_ref)
+                    required = merge_max_permissions(required, nested_required)
+
+        return required
+
+    def _is_local_ref(self, workflow_ref: ReusableWorkflowRef) -> bool:
+        if workflow_ref.owner is None:
+            return True
+        return (
+            workflow_ref.owner == self.local_owner
+            and workflow_ref.repo == self.local_repo
+        )
+
+    def _cache_key(self, workflow_ref: ReusableWorkflowRef) -> str:
+        if self._is_local_ref(workflow_ref):
+            return f"local:{workflow_ref.workflow_path}"
+        return (
+            f"remote:{workflow_ref.owner}/{workflow_ref.repo}/"
+            f"{workflow_ref.workflow_path}@{workflow_ref.ref or 'main'}"
+        )
+
+    def _default_fetch(
+        self, owner: str, repo: str, workflow_path: str, ref: str
+    ) -> str:
+        token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+        url = f"https://api.github.com/repos/{owner}/{repo}/contents/{workflow_path}?ref={ref}"
+        request = urllib.request.Request(url)
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                payload = json.load(response)
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"failed to fetch {owner}/{repo}/{workflow_path}@{ref}: HTTP {exc.code}"
+            ) from exc
+
+        content = payload.get("content")
+        if not isinstance(content, str):
+            raise RuntimeError(
+                f"unexpected GitHub API response for {owner}/{repo}/{workflow_path}@{ref}"
+            )
+        return base64.b64decode(content).decode("utf-8")

--- a/tests/test_validate_aw_workflow_permissions.py
+++ b/tests/test_validate_aw_workflow_permissions.py
@@ -1,0 +1,236 @@
+"""Tests for scripts/validate_aw_workflow_permissions.py."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "scripts"))
+
+import validate_aw_workflow_permissions as validator  # noqa: E402
+from workflow_permissions import WorkflowPermissionResolver  # noqa: E402
+
+
+def _write_workflow(path: pathlib.Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def test_validate_workflow_rejects_missing_discussions_for_gh_aw_callee(
+    tmp_path: pathlib.Path,
+) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+
+    callee = workflows / "oblt-aw-duplicate-issue-detector.yml"
+    _write_workflow(
+        callee,
+        {
+            "name": "Duplicate Issue Detector",
+            "on": {"workflow_call": None},
+            "permissions": {"contents": "read"},
+            "jobs": {
+                "duplicate-issue-detector": {
+                    "permissions": {
+                        "actions": "read",
+                        "contents": "read",
+                        "issues": "write",
+                        "pull-requests": "read",
+                        "copilot-requests": "write",
+                    },
+                    "uses": (
+                        "elastic/ai-github-actions/.github/workflows/"
+                        "gh-aw-duplicate-issue-detector.lock.yml@main"
+                    ),
+                }
+            },
+        },
+    )
+
+    caller = workflows / "oblt-aw-event-issues.yml"
+    _write_workflow(
+        caller,
+        {
+            "name": "Issues Event",
+            "on": {"workflow_call": None},
+            "permissions": {"contents": "read"},
+            "jobs": {
+                "duplicate-issue-detector": {
+                    "permissions": {
+                        "actions": "read",
+                        "contents": "read",
+                        "issues": "write",
+                        "pull-requests": "read",
+                        "copilot-requests": "write",
+                    },
+                    "uses": "./.github/workflows/oblt-aw-duplicate-issue-detector.yml",
+                }
+            },
+        },
+    )
+
+    lock_text = """
+name: gh-aw duplicate issue detector
+on:
+  workflow_call: {}
+permissions: {}
+jobs:
+  conclusion:
+    permissions:
+      contents: read
+      discussions: write
+      issues: write
+  safe_outputs:
+    permissions:
+      contents: read
+      discussions: write
+      issues: write
+"""
+
+    def fetch_remote(owner: str, repo: str, workflow_path: str, ref: str) -> str:
+        assert owner == "elastic"
+        assert repo == "ai-github-actions"
+        assert workflow_path.endswith("gh-aw-duplicate-issue-detector.lock.yml")
+        return lock_text
+
+    resolver = WorkflowPermissionResolver(workflows, fetch_remote_workflow=fetch_remote)
+    errors = validator.validate_workflow_file(caller, resolver)
+    assert any("discussions" in err for err in errors)
+
+
+def test_validate_workflow_accepts_aligned_local_and_remote_chain(
+    tmp_path: pathlib.Path,
+) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+
+    callee = workflows / "oblt-aw-duplicate-issue-detector.yml"
+    _write_workflow(
+        callee,
+        {
+            "name": "Duplicate Issue Detector",
+            "on": {"workflow_call": None},
+            "permissions": {"contents": "read"},
+            "jobs": {
+                "duplicate-issue-detector": {
+                    "permissions": {
+                        "actions": "read",
+                        "contents": "read",
+                        "discussions": "write",
+                        "issues": "write",
+                        "pull-requests": "read",
+                        "copilot-requests": "write",
+                    },
+                    "uses": (
+                        "elastic/ai-github-actions/.github/workflows/"
+                        "gh-aw-duplicate-issue-detector.lock.yml@main"
+                    ),
+                }
+            },
+        },
+    )
+
+    caller = workflows / "oblt-aw-event-issues.yml"
+    _write_workflow(
+        caller,
+        {
+            "name": "Issues Event",
+            "on": {"workflow_call": None},
+            "permissions": {"contents": "read"},
+            "jobs": {
+                "duplicate-issue-detector": {
+                    "permissions": {
+                        "actions": "read",
+                        "contents": "read",
+                        "discussions": "write",
+                        "issues": "write",
+                        "pull-requests": "read",
+                        "copilot-requests": "write",
+                    },
+                    "uses": "./.github/workflows/oblt-aw-duplicate-issue-detector.yml",
+                }
+            },
+        },
+    )
+
+    lock_text = """
+name: gh-aw duplicate issue detector
+on:
+  workflow_call: {}
+permissions: {}
+jobs:
+  conclusion:
+    permissions:
+      contents: read
+      discussions: write
+      issues: write
+"""
+
+    resolver = WorkflowPermissionResolver(
+        workflows,
+        fetch_remote_workflow=lambda *_args, **_kwargs: lock_text,
+    )
+    assert validator.validate_workflow_file(caller, resolver) == []
+    assert validator.validate_workflow_file(callee, resolver) == []
+
+
+def test_validate_workflow_maps_elastic_oblt_aw_ref_to_local_file(
+    tmp_path: pathlib.Path,
+) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+
+    event = workflows / "oblt-aw-event-issues.yml"
+    _write_workflow(
+        event,
+        {
+            "name": "Issues Event",
+            "on": {"workflow_call": None},
+            "permissions": {"contents": "read"},
+            "jobs": {
+                "issue-triage": {
+                    "permissions": {"contents": "read", "issues": "write"},
+                    "uses": "./.github/workflows/oblt-aw-issue-triage.yml",
+                }
+            },
+        },
+    )
+
+    route = workflows / "oblt-aw-issue-triage.yml"
+    _write_workflow(
+        route,
+        {
+            "name": "Issue Triage",
+            "on": {"workflow_call": None},
+            "permissions": {"contents": "read"},
+            "jobs": {
+                "noop": {
+                    "runs-on": "ubuntu-latest",
+                    "steps": [{"run": "echo ok"}],
+                }
+            },
+        },
+    )
+
+    trigger = workflows / "trigger-oblt-aw-issues.yml"
+    _write_workflow(
+        trigger,
+        {
+            "name": "Trigger",
+            "on": {"issues": None},
+            "permissions": {"contents": "read"},
+            "jobs": {
+                "run-aw": {
+                    "permissions": {"contents": "read", "issues": "write"},
+                    "uses": (
+                        "elastic/oblt-aw/.github/workflows/"
+                        "oblt-aw-event-issues.yml@main"
+                    ),
+                }
+            },
+        },
+    )
+
+    resolver = WorkflowPermissionResolver(workflows)
+    assert validator.validate_workflow_file(trigger, resolver) == []


### PR DESCRIPTION
## Summary
- Fix `duplicate-issue-detector` permission misalignment by granting `discussions: write` on the issues orchestrator and route jobs.
- Add `validate_aw_workflow_permissions.py` to CI so caller job scopes are checked against callee ceilings, including nested `gh-aw-*` lock files fetched from `elastic/ai-github-actions` and `elastic/docs-actions`.
- Align docs GH-AW routes surfaced by the new validator (`copilot-requests: write` on docs AI menu jobs).

## Test plan
- [x] `pytest tests/test_validate_aw_workflow_permissions.py -v`
- [x] `pytest tests/ -v`
- [x] `python scripts/validate_aw_workflow_permissions.py` (73 reusable-workflow calls validated)
- [x] `python scripts/validate_aw_workflow_prelude.py`
- [x] `python scripts/validate_aw_workflow_resolve_agentic_assets.py`

Fixes https://github.com/elastic/oblt-aw/actions/runs/28082381315
Related issue: https://github.com/elastic/observability-robots/issues/4681