### PR TITLE
oblt-aw-estc-pr-buildkite-detective: run for PRs only

### DIFF
--- a/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
+++ b/.github/workflows/oblt-aw-estc-pr-buildkite-detective.yml
@@ -31,11 +31,33 @@ permissions:
 
 jobs:
 
-  resolve-apm-assets:
+  check-pr:
     if: >-
       github.event_name == 'status' &&
       github.event.state == 'failure' &&
       contains(github.event.context, 'buildkite')
+    runs-on: ubuntu-latest
+    outputs:
+      has-open-pr: ${{ steps.find-pr.outputs.has-open-pr }}
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check for open PR associated with commit
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.sha }}/pulls" \
+            --jq '[.[] | select(.state == "open")] | length')
+          if [ "$count" -gt 0 ]; then
+            echo "has-open-pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-open-pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  resolve-apm-assets:
+    if: needs.check-pr.outputs.has-open-pr == 'true'
+    needs: [check-pr]
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
See the required permissions at https://docs.github.com/en/rest/commits/commits?apiVersion=2026-03-10#list-pull-requests-associated-with-a-commit

this should help with reducing the CI cycles for unrequired commits, otherwise, it fails when accessing commits that are not belonging to a PR but a ref branch